### PR TITLE
SpatialAlignmentProblem

### DIFF
--- a/moscot/framework/_spatial_problems.py
+++ b/moscot/framework/_spatial_problems.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from typing import Any, Tuple, Optional, Sequence
+
+import numpy as np
+
+from anndata import AnnData
+
+from moscot.framework.BaseProblem import BaseProblem
+from moscot._constants._pkg_constants import Key
+
+
+class BaseSpatialProblem(BaseProblem):
+    """Base spatial problem."""
+
+    def __init__(self, adata: AnnData, spatial_key: str = Key.obsm.spatial) -> None:
+        """Init docs."""
+        _assert_spatial_basis(adata, spatial_key)
+        self._adata = adata
+        self._rep = adata.obsm[spatial_key]
+        super().__init__(adata=adata, rep=self._rep)
+
+    def prepare(
+        self,
+        reference_key: str,
+        target_key: str,
+        batch_key: str = Key.obs.batch_key,
+        alt_var: Optional[str | None] = None,
+        **kwargs: Any,
+    ) -> None:
+        """Prepare docs."""
+        _assert_value_in_obs(self.adata, batch_key, reference_key)
+        _assert_value_in_obs(self.adata, batch_key, target_key)
+
+        # subset adata.obs to get query and reference
+        super().prepare(**kwargs)
+
+
+class SpatialMappingProblem(BaseSpatialProblem):
+    """Spatial Mapping Problem."""
+
+    def prepare(
+        self,
+        reference_vars: Optional[Sequence[str] | str | None] = None,
+        **kwargs: Any,
+    ):
+        """Prepare docs."""
+        _assert_vars(self.adata, reference_vars)
+        super().prepare(**kwargs)
+
+
+class SpatialAlignmentProblem(BaseSpatialProblem):
+    """Spatial Alignment Problem."""
+
+    def prepare(
+        self,
+        **kwargs: Any,
+    ):
+        """Prepare docs."""
+        super().prepare(**kwargs)
+
+    def align(
+        *,
+        copy: bool = False,
+    ) -> Tuple[Sequence[np.ndarray], Tuple[Sequence[float], Sequence[float]]] | None:
+        """Align docs."""
+        if copy:
+            pass  # return aligned coordinates, rotation and translation factors
+
+
+def _assert_spatial_basis(adata: AnnData, key: str) -> None:
+    if key not in adata.obsm:
+        raise KeyError(f"Spatial basis `{key}` not found in `adata.obsm`.")
+
+
+def _assert_value_in_obs(adata: AnnData, key: str, val: Any) -> None:
+    if key not in adata.obs:
+        raise KeyError(f"Cluster key `{key}` not found in `adata.obs`.")
+    if not isinstance(val, str):
+        val = [val]
+    if np.setdiff1d(val, adata.obs[key].unique()).shape[0] == 0:
+        raise ValueError(f"`values: {val}` not found in `adata.obs[{key}]`.")
+
+
+def _assert_vars(adata: AnnData, var: Sequence[str] | str) -> None:
+    if isinstance(var, str):
+        var = [var]
+    if np.setdiff1d(var, adata.var_names).shape[0] == 0:
+        raise ValueError(f"`var: {var}` not found in `adata.var_names`.")


### PR DESCRIPTION
Few questions I have after this minor draft:

#### Conceptual:
Find it urgent to define behaviour of how solvers interact with problems when multiple problems are set. Let's take the simple example of one reference and many query:

```python
# subset
adata_ref = adata[adata.obs["batch_key"] == ref_key]
adata_tgt = [adata_ref = adata[adata.obs["batch_key"] == tg_key] for tg_key in target_key]

# prepare
... # calculate costs etc.

# solve
res = []
for ad_tgt in adata_tgt:
	res.append(solve(adata_ref, ad_tgt))	
```
- I think it makes sense to assume that users have everything in one anndata (both the reference and query mapping), but also it might be that they are separated. Do we agree? How do we handle this? Can become very complicated quickly so I would keep it simple at the beginning.
- Where does the subsetting happens? in `init` or `prepare` ? I'd vote for init cause then the metric space is only built for refs and targets (at the prepare stage).
- How is the subset followed through? I vote for a list of keys or indexes in order to then use them for downstream methods (e.g. actually mapping gene activity to 
- What should the solver and prepare take as input and return as output? My point is that is should either contain the arrays on which to perform computations, or the set of keys to subset the anndata object? Useful to know at this stage for me.
- how is the result returned? e.g. is it a (dense?) array assigned to the class? Useful to know cause then I can develop the downstream boilerplate code for using the learnt mapping.
- Since I'm not super familiar with the terminology (still) I would really benefit from some basic comments around the code and/or their shape. E.g. for marginals would be useful to have a comment like # shape: (N,) at init. Thanks

From my side, the basic API I think it would look like this
```python
problem = SpatialMappingProblem() # keys to subset/access adatas
problem.prepare() # build distance matrices etc.
problem.solve() # do the actual computation
problem.downstream() # use results to return useful stuff for users (e.g. mapped genes, rotated coordinates etc.)
```
Having some basic structure on how the input/output of each method is handled would be very useful.

#### Development
- mypy throws tons of errors at pre-commit stage for files I didn't touch 🤷 . For files I touched, it's still pretty ruthless. Do we want to keep it in full blown even at this early stage?
- what is the framework folder for? I see the most recent files are there but should then be in the root module folder? i'd find restructuring useful at this stage so I know which files I should refer to
- I've init the package constants, it's something I learnt from Michal and am very fond of. I'd suggest to use it here as well.
- do we want to call them problems? I actually think estimator is nicer 😅 