### PR TITLE
Fix pandas 2 error with lineage tree loading

### DIFF
--- a/src/moscot/datasets.py
+++ b/src/moscot/datasets.py
@@ -178,9 +178,9 @@ def c_elegans(
         force_download=force_download,
         **kwargs,
     )
-    # TODO(michalk8): also cache or store in AnnData ad Newick + reconstruct?
-    with urllib.request.urlopen("https://figshare.com/ndownloader/files/39943603") as fin:
-        tree = pickle.load(fin)
+
+    with urllib.request.urlopen("https://figshare.com/ndownloader/files/43064842") as fin:
+        tree = nx.read_gml(fin)
 
     return adata, tree
 


### PR DESCRIPTION
Hi @michalk8, this is one way of fixing an error that occurred to me when trying to read in the C. elegans lineage trees via `adata, tree = moscot.datasets.c_elegans()`, see https://github.com/theislab/moscot/issues/625. 

The problem was that node information was stored in DataFrames, which somehow caused a problem in pandas 2. I now convert dataframes to dict and save the tree in `gml` format. 

Ideally, the tree would also be cached, just like the AnnData object, but this might be fine for now?

closes #625 