### PR TITLE
Tests that ignore alpha and xy compatibility 

### DIFF
--- a/tests/problems/cross_modality/test_translation_problem.py
+++ b/tests/problems/cross_modality/test_translation_problem.py
@@ -108,6 +108,8 @@ class TestTranslationProblem:
         tp = tp.solve(epsilon=epsilon, alpha=alpha, rank=rank, **kwargs)
 
         for key, subsol in tp.solutions.items():
+            if tp[key].xy is None:
+                assert alpha == 1.0, f"xy={tp[key].xy} but alpha={alpha}"
             assert isinstance(subsol, BaseSolverOutput)
             assert key in expected_keys
             assert tp[key].solution.rank == rank

--- a/tests/problems/space/test_mapping_problem.py
+++ b/tests/problems/space/test_mapping_problem.py
@@ -122,6 +122,8 @@ class TestMappingProblem:
         mp = mp.solve(epsilon=epsilon, alpha=alpha, rank=rank, **kwargs)
 
         for prob_key in mp:
+            if alpha != 1.0:
+                assert mp[prob_key].xy is not None, f"xy={mp[prob_key].xy}, alpha={alpha}"
             assert mp[prob_key].solution.rank == rank
             if initializer != "random":  # TODO: is this valid?
                 assert mp[prob_key].solution.converged


### PR DESCRIPTION
Hi,

there are two tests that create a problem when xy and alpha are not compatible. Part of https://github.com/theislab/moscot/issues/680. Once you agree I will make sure in https://github.com/theislab/moscot/pull/681 these tests will be refactored.

ping: @giovp , @MUCDK 