### PR TITLE
Feat/lin spatial map

### DIFF
--- a/src/moscot/problems/space/__init__.py
+++ b/src/moscot/problems/space/__init__.py
@@ -1,10 +1,12 @@
 from moscot.problems.space._alignment import AlignmentProblem
+from moscot.problems.space._linear_mapping import LinearMappingProblem
 from moscot.problems.space._mapping import MappingProblem
 from moscot.problems.space._mixins import SpatialAlignmentMixin, SpatialMappingMixin
 
 __all__ = [
     "AlignmentProblem",
     "MappingProblem",
+    "LinearMappingProblem",
     "SpatialAlignmentMixin",
     "SpatialMappingMixin",
 ]

--- a/src/moscot/problems/space/_linear_mapping.py
+++ b/src/moscot/problems/space/_linear_mapping.py
@@ -1,0 +1,320 @@
+import types
+from typing import Any, Literal, Mapping, Optional, Sequence, Tuple, Type, Union
+
+from anndata import AnnData
+
+from moscot import _constants
+from moscot._types import (  # QuadInitializer_t,
+    ArrayLike,
+    CostKwargs_t,
+    OttCostFn_t,
+    Policy_t,
+    ProblemStage_t,
+    ScaleCost_t,
+    SinkhornInitializer_t,
+)
+from moscot.base.problems.compound_problem import B, CompoundProblem, K
+from moscot.base.problems.problem import OTProblem
+from moscot.problems._utils import handle_cost, handle_joint_attr
+from moscot.problems.space._mixins import SpatialMappingMixin
+from moscot.utils.subset_policy import DummyPolicy, ExternalStarPolicy
+
+__all__ = ["LinearMappingProblem"]
+
+
+class LinearMappingProblem(SpatialMappingMixin[K, OTProblem], CompoundProblem[K, OTProblem]):
+    """Class for mapping single cell omics data onto spatial data, based on :cite:`nitzan:19`.
+
+    Parameters
+    ----------
+    adata_sc
+        Annotated data object containing the single-cell data.
+    adata_sp
+        Annotated data object containing the spatial data.
+    """
+
+    def __init__(self, adata_sc: AnnData, adata_sp: AnnData):
+        super().__init__(adata_sp)
+        self._adata_sc = adata_sc
+        # TODO(michalk8): rename to common_vars?
+        self.filtered_vars: Optional[Sequence[str]] = None
+
+    def _create_policy(
+        self,
+        policy: Literal["external_star"] = "external_star",
+        key: Optional[str] = None,
+        **kwargs: Any,
+    ) -> Union[DummyPolicy, ExternalStarPolicy[K]]:
+        del policy
+        if key is None:
+            return DummyPolicy(self.adata, **kwargs)
+        return ExternalStarPolicy(self.adata, key=key, **kwargs)
+
+    def _create_problem(
+        self,
+        src: K,
+        tgt: K,
+        src_mask: ArrayLike,
+        tgt_mask: ArrayLike,
+        **kwargs: Any,
+    ) -> OTProblem:
+        return self._base_problem_type(
+            adata=self.adata_sp,
+            adata_tgt=self.adata_sc,
+            src_obs_mask=src_mask,
+            tgt_obs_mask=None,
+            src_var_mask=self.filtered_vars,  # type: ignore[arg-type]
+            tgt_var_mask=self.filtered_vars,  # type: ignore[arg-type]
+            src_key=src,
+            tgt_key=tgt,
+            **kwargs,
+        )
+
+    def prepare(
+        self,
+        # sc_attr: Union[str, Mapping[str, Any]],
+        batch_key: Optional[str] = None,
+        # spatial_key: Union[str, Mapping[str, Any]] = "spatial",
+        # var_names: Optional[Sequence[str]] = None,
+        # normalize_spatial: bool = True,
+        joint_attr: Optional[Union[str, Mapping[str, Any]]] = None,
+        # cost: OttCostFnMap_t = "sq_euclidean",
+        cost: OttCostFn_t = "sq_euclidean",
+        cost_kwargs: CostKwargs_t = types.MappingProxyType({}),
+        a: Optional[str] = None,
+        b: Optional[str] = None,
+        **kwargs: Any,
+    ) -> "LinearMappingProblem[K]":
+        """Prepare the mapping problem problem.
+
+        .. seealso::
+            - See :doc:`../notebooks/tutorials/400_spatial_mapping` on how to
+              prepare and solve the :class:`~moscot.problems.space.MappingProblem`.
+
+        Parameters
+        ----------
+        sc_attr
+            How to get the data for the :term:`quadratic term`. Usually, it’s the :attr:`~anndata.AnnData.X` attribute,
+            which contains normalized counts, but a different modality or a pre-computed
+            `PCA <https://en.wikipedia.org/wiki/Principal_component_analysis>`_ can also be used. Valid options are:
+
+            - :class:`str` - a key in :attr:`~anndata.AnnData.obsm`.
+            - :class:`dict` -  it should contain ``'attr'`` and ``'key'``, the attribute and key in
+              :class:`~anndata.AnnData`, and optionally ``'tag'`` from the
+              :class:`tags <moscot.utils.tagged_array.Tag>`.
+
+            By default, :attr:`tag = 'point_cloud' <moscot.utils.tagged_array.Tag.POINT_CLOUD>` is used.
+        batch_key
+            Key in :attr:`~anndata.AnnData.obs` where the slices are stored.
+        spatial_key
+            Key in :attr:`~anndata.AnnData.obsm` where the spatial coordinates are stored.
+        var_names
+            Genes in :attr:`~anndata.AnnData.var_names` for the :term:`linear term` in the
+            :term:`fused <fused Gromov-Wasserstein>` case. Valid options are:
+
+            - :obj:`None` - use all genes shared between :attr:`adata_sp` and :attr:`adata_sc`.
+            - :class:`~typing.Sequence` - use a subset of genes. If an empty sequence, the problem will correspond
+              to the pure :term:`Gromov-Wasserstein` case.
+
+            See also the ``joint_attribute`` parameter.
+        normalize_spatial
+            Whether to normalize the spatial coordinates. If :obj:`True`, the coordinates are normalized
+            by standardizing them.
+        joint_attr
+            How to get the data for the :term:`linear term` in the :term:`fused <fused Gromov-Wasserstein>` case:
+
+            - :obj:`None` - `PCA <https://en.wikipedia.org/wiki/Principal_component_analysis>`_
+              on :attr:`~anndata.AnnData.X` is computed.
+            - :class:`str` - key in :attr:`~anndata.AnnData.obsm` where the data is stored.
+            - :class:`dict` -  it should contain ``'attr'`` and ``'key'``, the attribute and key in
+              :class:`~anndata.AnnData`, and optionally ``'tag'`` from the
+              :class:`tags <moscot.utils.tagged_array.Tag>`.
+        cost
+            Cost function to use. Valid options are:
+
+            - :class:`str` - name of the cost function for all terms, see :func:`~moscot.costs.get_available_costs`.
+            - :class:`dict` - a dictionary with the following keys and values:
+
+              - ``'xy'`` - cost function for the :term:`linear term`.
+              - ``'x'`` - cost function for the source :term:`quadratic term`.
+              - ``'y'`` - cost function for the target :term:`quadratic term`.
+        cost_kwargs
+            Keyword arguments for the :class:`~moscot.base.cost.BaseCost` or any backend-specific cost.
+        a
+            Source :term:`marginals`. Valid options are:
+
+            - :class:`str` - key in :attr:`~anndata.AnnData.obs` where the source marginals are stored.
+            - :class:`bool` - if :obj:`True`,
+              :meth:`estimate the marginals <moscot.base.problems.OTProblem.estimate_marginals>`,
+              otherwise use uniform marginals.
+            - :obj:`None` - uniform marginals.
+        b
+            Target :term:`marginals`. Valid options are:
+
+            - :class:`str` - key in :attr:`~anndata.AnnData.obs` where the target marginals are stored.
+            - :class:`bool` - if :obj:`True`,
+              :meth:`estimate the marginals <moscot.base.problems.OTProblem.estimate_marginals>`,
+              otherwise use uniform marginals.
+            - :obj:`None` - uniform marginals.
+        kwargs
+            Keyword arguments for :meth:`~moscot.base.problems.CompoundProblem.prepare`.
+
+        Returns
+        -------
+        Returns self and updates the following fields:
+
+        - :attr:`problems` - the prepared subproblems.
+        - :attr:`solutions` - set to an empty :class:`dict`.
+        - :attr:`spatial_key` - key in :attr:`~anndata.AnnData.obsm` where the spatial coordinates are stored.
+        - :attr:`batch_key` - key in :attr:`~anndata.AnnData.obs` where batches are stored.
+        - :attr:`stage` - set to ``'prepared'``.
+        - :attr:`problem_kind` - set to ``'quadratic'``.
+        """
+        # x = {"attr": "obsm", "key": spatial_key} if isinstance(spatial_key, str) else spatial_key
+        # y = {"attr": "obsm", "key": sc_attr} if isinstance(sc_attr, str) else sc_attr
+
+        # if normalize_spatial and "x_callback" not in kwargs:
+        #     kwargs["x_callback"] = "spatial-norm"
+        #     kwargs.setdefault("x_callback_kwargs", x)
+        # if "spatial-norm" in kwargs.get("x_callback", {}):
+        #     x = {}
+
+        # self.batch_key = batch_key
+        # self.spatial_key = spatial_key if isinstance(spatial_key, str) else spatial_key["key"]
+        # self.filtered_vars = var_names
+
+        xy, kwargs = handle_joint_attr(joint_attr, kwargs)
+        xy, x, y = handle_cost(
+            xy=xy, x=kwargs.pop("x", {}), y=kwargs.pop("y", {}), cost=cost, cost_kwargs=cost_kwargs, **kwargs
+        )
+
+        return super().prepare(  # type: ignore[return-value]
+            xy=xy, x=x, y=y, policy="external_star", key=batch_key, cost=None, a=a, b=b, **kwargs
+        )
+
+    def solve(
+        self,
+        # alpha: float = 0.5,
+        epsilon: float = 1e-2,
+        tau_a: float = 1.0,
+        tau_b: float = 1.0,
+        rank: int = -1,
+        scale_cost: ScaleCost_t = "mean",
+        batch_size: Optional[int] = None,
+        stage: Union[ProblemStage_t, Tuple[ProblemStage_t, ...]] = ("prepared", "solved"),
+        # initializer: QuadInitializer_t = None,
+        initializer: SinkhornInitializer_t = None,
+        initializer_kwargs: Mapping[str, Any] = types.MappingProxyType({}),
+        jit: bool = True,
+        threshold: float = 1e-3,
+        min_iterations: Optional[int] = None,
+        max_iterations: Optional[int] = None,
+        # linear_solver_kwargs: Mapping[str, Any] = types.MappingProxyType({}),
+        device: Optional[Literal["cpu", "gpu", "tpu"]] = None,
+        **kwargs: Any,
+    ) -> "LinearMappingProblem[K]":
+        r"""Solve the mapping problem.
+
+        .. seealso::
+            - See :doc:`../notebooks/tutorials/400_spatial_mapping` on how to
+              prepare and solve the :class:`~moscot.problems.space.MappingProblem`.
+
+        Parameters
+        ----------
+        alpha
+            Parameter in :math:`(0, 1]` that interpolates between the :term:`quadratic term` and
+            the :term:`linear term`. :math:`\alpha = 1` corresponds to the pure :term:`Gromov-Wasserstein` problem while
+            :math:`\alpha \to 0` corresponds to the pure :term:`linear problem`.
+        epsilon
+            :term:`Entropic regularization`.
+        tau_a
+            Parameter in :math:`(0, 1]` that defines how much :term:`unbalanced <unbalanced OT problem>` is the problem
+            on the source :term:`marginals`. If :math:`1`, the problem is :term:`balanced <balanced OT problem>`.
+        tau_b
+            Parameter in :math:`(0, 1]` that defines how much :term:`unbalanced <unbalanced OT problem>` is the problem
+            on the target :term:`marginals`. If :math:`1`, the problem is :term:`balanced <balanced OT problem>`.
+        rank
+            Rank of the :term:`low-rank OT` solver :cite:`scetbon:21b`.
+            If :math:`-1`, full-rank solver :cite:`peyre:2016` is used.
+        scale_cost
+            How to re-scale the cost matrices. If a :class:`float`, the cost matrices
+            will be re-scaled as :math:`\frac{\text{cost}}{\text{scale_cost}}`.
+        batch_size
+            Number of rows/columns of the cost matrix to materialize during the solver iterations.
+            Larger value will require more memory.
+        stage
+            Stage by which to filter the :attr:`problems` to be solved.
+        initializer
+            How to initialize the solution. If :obj:`None`, ``'default'`` will be used for a full-rank solver and
+            ``'rank2'`` for a low-rank solver.
+        initializer_kwargs
+            Keyword arguments for the ``initializer``.
+        jit
+            Whether to :func:`~jax.jit` the underlying :mod:`ott` solver.
+        min_iterations
+            Minimum number of :term:`(fused) GW <Gromov-Wasserstein>` iterations.
+        max_iterations
+            Maximum number of :term:`(fused) GW <Gromov-Wasserstein>` iterations.
+        threshold
+            Convergence threshold of the :term:`GW <Gromov-Wasserstein>` solver.
+        linear_solver_kwargs
+            Keyword arguments for the inner :term:`linear problem` solver.
+        device
+            Transfer the solution to a different device, see :meth:`~moscot.base.output.BaseSolverOutput.to`.
+            If :obj:`None`, keep the output on the original device.
+        kwargs
+            Keyword arguments for :meth:`~moscot.base.problems.CompoundProblem.solve`.
+
+        Returns
+        -------
+        Returns self and updates the following fields:
+
+        - :attr:`solutions` - the :term:`OT` solutions for each subproblem.
+        - :attr:`stage` - set to ``'solved'``.
+        """
+        return super().solve(  # type: ignore[return-value]
+            # alpha=alpha,
+            epsilon=epsilon,
+            tau_a=tau_a,
+            tau_b=tau_b,
+            rank=rank,
+            scale_cost=scale_cost,
+            batch_size=batch_size,
+            stage=stage,
+            initializer=initializer,
+            initializer_kwargs=initializer_kwargs,
+            jit=jit,
+            threshold=threshold,
+            min_iterations=min_iterations,
+            max_iterations=max_iterations,
+            # linear_solver_kwargs=linear_solver_kwargs,
+            device=device,
+            **kwargs,
+        )
+
+    @property
+    def adata_sc(self) -> AnnData:
+        """Single-cell data."""
+        return self._adata_sc
+
+    @property
+    def adata_sp(self) -> AnnData:
+        """Spatial data, alias for :attr:`adata`."""
+        return self.adata
+
+    @property
+    def filtered_vars(self) -> Optional[Sequence[str]]:
+        """Filtered variables."""
+        return self._filtered_vars
+
+    @filtered_vars.setter
+    def filtered_vars(self, value: Optional[Sequence[str]]) -> None:
+        self._filtered_vars = self._filter_vars(var_names=value)  # type: ignore[misc]
+
+    @property
+    def _base_problem_type(self) -> Type[B]:
+        return OTProblem  # type: ignore[return-value]
+
+    @property
+    def _valid_policies(self) -> Tuple[Policy_t, ...]:
+        return _constants.EXTERNAL_STAR, _constants.DUMMY  # type: ignore[return-value]

--- a/src/moscot/problems/space/_linear_mapping.py
+++ b/src/moscot/problems/space/_linear_mapping.py
@@ -159,6 +159,8 @@ class LinearMappingProblem(SpatialMappingMixin[K, OTProblem], CompoundProblem[K,
         initializer_kwargs: Mapping[str, Any] = types.MappingProxyType({}),
         jit: bool = True,
         threshold: float = 1e-3,
+        lse_mode: bool = True,
+        inner_iterations: int = 10,
         min_iterations: Optional[int] = None,
         max_iterations: Optional[int] = None,
         device: Optional[Literal["cpu", "gpu", "tpu"]] = None,
@@ -207,6 +209,12 @@ class LinearMappingProblem(SpatialMappingMixin[K, OTProblem], CompoundProblem[K,
             this is typically the deviation between the target :term:`marginals` and the marginals of the current
             :term:`transport matrix`. In the :term:`unbalanced <unbalanced OT problem>` case, the relative change
             between the successive solutions is checked.
+        lse_mode
+            Whether to use `log-sum-exp (LSE)
+            <https://en.wikipedia.org/wiki/LogSumExp#log-sum-exp_trick_for_log-domain_calculations>`_
+            computations for numerical stability.
+        inner_iterations
+            Compute the convergence criterion every ``inner_iterations``.
         device
             Transfer the solution to a different device, see :meth:`~moscot.base.output.BaseSolverOutput.to`.
             If :obj:`None`, keep the output on the original device.
@@ -232,6 +240,8 @@ class LinearMappingProblem(SpatialMappingMixin[K, OTProblem], CompoundProblem[K,
             initializer_kwargs=initializer_kwargs,
             jit=jit,
             threshold=threshold,
+            lse_mode=lse_mode,
+            inner_iterations=inner_iterations,
             min_iterations=min_iterations,
             max_iterations=max_iterations,
             device=device,

--- a/src/moscot/problems/space/_linear_mapping.py
+++ b/src/moscot/problems/space/_linear_mapping.py
@@ -76,6 +76,7 @@ class LinearMappingProblem(SpatialMappingMixin[K, OTProblem], CompoundProblem[K,
         self,
         batch_key: Optional[str] = None,
         spatial_key: Union[str, Mapping[str, Any]] = "spatial",
+        var_names: Optional[Sequence[str]] = None,
         joint_attr: Optional[Union[str, Mapping[str, Any]]] = None,
         cost: OttCostFn_t = "sq_euclidean",
         cost_kwargs: CostKwargs_t = types.MappingProxyType({}),
@@ -91,6 +92,13 @@ class LinearMappingProblem(SpatialMappingMixin[K, OTProblem], CompoundProblem[K,
             Key in :attr:`~anndata.AnnData.obs` where the slices are stored.
         spatial_key
             Key in :attr:`~anndata.AnnData.obsm` where the spatial coordinates are stored.
+        var_names
+            Genes in :attr:`~anndata.AnnData.var_names` for the :term:`linear term`. Valid options are:
+
+            - :obj:`None` - use all genes shared between :attr:`adata_sp` and :attr:`adata_sc`.
+            - :class:`~typing.Sequence` - use a subset of genes.
+
+            See also the ``joint_attribute`` parameter.
         joint_attr
             How to get the data that defines the :term:`linear problem`:
 
@@ -143,8 +151,13 @@ class LinearMappingProblem(SpatialMappingMixin[K, OTProblem], CompoundProblem[K,
         """
         self.spatial_key = spatial_key if isinstance(spatial_key, str) else spatial_key["key"]
         self.batch_key = batch_key
+        self.filtered_vars = var_names
 
-        xy, kwargs = handle_joint_attr(joint_attr, kwargs)
+        if self.filtered_vars is not None:
+            xy, kwargs = handle_joint_attr(joint_attr, kwargs)
+        else:
+            xy = {}
+
         xy, x, y = handle_cost(
             xy=xy, x=kwargs.pop("x", {}), y=kwargs.pop("y", {}), cost=cost, cost_kwargs=cost_kwargs, **kwargs
         )

--- a/src/moscot/problems/space/_linear_mapping.py
+++ b/src/moscot/problems/space/_linear_mapping.py
@@ -75,6 +75,7 @@ class LinearMappingProblem(SpatialMappingMixin[K, OTProblem], CompoundProblem[K,
     def prepare(
         self,
         batch_key: Optional[str] = None,
+        spatial_key: Union[str, Mapping[str, Any]] = "spatial",
         joint_attr: Optional[Union[str, Mapping[str, Any]]] = None,
         cost: OttCostFn_t = "sq_euclidean",
         cost_kwargs: CostKwargs_t = types.MappingProxyType({}),
@@ -88,6 +89,8 @@ class LinearMappingProblem(SpatialMappingMixin[K, OTProblem], CompoundProblem[K,
         ----------
         batch_key
             Key in :attr:`~anndata.AnnData.obs` where the slices are stored.
+        spatial_key
+            Key in :attr:`~anndata.AnnData.obsm` where the spatial coordinates are stored.
         joint_attr
             How to get the data that defines the :term:`linear problem`:
 
@@ -133,10 +136,14 @@ class LinearMappingProblem(SpatialMappingMixin[K, OTProblem], CompoundProblem[K,
 
         - :attr:`problems` - the prepared subproblems.
         - :attr:`solutions` - set to an empty :class:`dict`.
+        - :attr:`spatial_key` - key in :attr:`~anndata.AnnData.obsm` where the spatial coordinates are stored.
         - :attr:`batch_key` - key in :attr:`~anndata.AnnData.obs` where batches are stored.
         - :attr:`stage` - set to ``'prepared'``.
         - :attr:`problem_kind` - set to ``'linear'``.
         """
+        self.spatial_key = spatial_key if isinstance(spatial_key, str) else spatial_key["key"]
+        self.batch_key = batch_key
+
         xy, kwargs = handle_joint_attr(joint_attr, kwargs)
         xy, x, y = handle_cost(
             xy=xy, x=kwargs.pop("x", {}), y=kwargs.pop("y", {}), cost=cost, cost_kwargs=cost_kwargs, **kwargs

--- a/src/moscot/problems/space/_linear_mapping.py
+++ b/src/moscot/problems/space/_linear_mapping.py
@@ -89,7 +89,7 @@ class LinearMappingProblem(SpatialMappingMixin[K, OTProblem], CompoundProblem[K,
         batch_key
             Key in :attr:`~anndata.AnnData.obs` where the slices are stored.
         joint_attr
-            How to get the data for the :term:`linear term` in the :term:`fused <fused Gromov-Wasserstein>` case:
+            How to get the data that defines the :term:`linear problem`:
 
             - :obj:`None` - `PCA <https://en.wikipedia.org/wiki/Principal_component_analysis>`_
               on :attr:`~anndata.AnnData.X` is computed.
@@ -97,15 +97,15 @@ class LinearMappingProblem(SpatialMappingMixin[K, OTProblem], CompoundProblem[K,
             - :class:`dict` -  it should contain ``'attr'`` and ``'key'``, the attribute and key in
               :class:`~anndata.AnnData`, and optionally ``'tag'`` from the
               :class:`tags <moscot.utils.tagged_array.Tag>`.
+
+            By default, :attr:`tag = 'point_cloud' <moscot.utils.tagged_array.Tag.POINT_CLOUD>` is used.
         cost
             Cost function to use. Valid options are:
 
-            - :class:`str` - name of the cost function for all terms, see :func:`~moscot.costs.get_available_costs`.
+            - :class:`str` - name of the cost function, see :func:`~moscot.costs.get_available_costs`.
             - :class:`dict` - a dictionary with the following keys and values:
 
-              - ``'xy'`` - cost function for the :term:`linear term`.
-              - ``'x'`` - cost function for the source :term:`quadratic term`.
-              - ``'y'`` - cost function for the target :term:`quadratic term`.
+              - ``'xy'`` - cost function for the :term:`linear term`, same as above.
         cost_kwargs
             Keyword arguments for the :class:`~moscot.base.cost.BaseCost` or any backend-specific cost.
         a
@@ -148,7 +148,7 @@ class LinearMappingProblem(SpatialMappingMixin[K, OTProblem], CompoundProblem[K,
 
     def solve(
         self,
-        epsilon: float = 1e-2,
+        epsilon: float = 1e-3,
         tau_a: float = 1.0,
         tau_b: float = 1.0,
         rank: int = -1,
@@ -183,8 +183,8 @@ class LinearMappingProblem(SpatialMappingMixin[K, OTProblem], CompoundProblem[K,
             Parameter in :math:`(0, 1]` that defines how much :term:`unbalanced <unbalanced OT problem>` is the problem
             on the target :term:`marginals`. If :math:`1`, the problem is :term:`balanced <balanced OT problem>`.
         rank
-            Rank of the :term:`low-rank OT` solver :cite:`scetbon:21b`.
-            If :math:`-1`, full-rank solver :cite:`peyre:2016` is used.
+            Rank of the :term:`low-rank OT` solver :cite:`scetbon:21a`.
+            If :math:`-1`, full-rank solver :cite:`cuturi:2013` is used.
         scale_cost
             How to re-scale the cost matrices. If a :class:`float`, the cost matrices
             will be re-scaled as :math:`\frac{\text{cost}}{\text{scale_cost}}`.

--- a/src/moscot/problems/space/_mixins.py
+++ b/src/moscot/problems/space/_mixins.py
@@ -397,7 +397,8 @@ class SpatialMappingMixin(AnalysisMixin[K, B]):
         var_names: Optional[Sequence[str]] = None,
         corr_method: Literal["pearson", "spearman"] = "pearson",
         device: Optional[Device_t] = None,
-    ) -> Mapping[Tuple[K, K], pd.Series]:
+        groupby: Optional[str] = None,
+    ) -> Mapping[Any, Mapping[Tuple[K, K], pd.Series]]:
         """Correlate true and predicted gene expression.
 
         .. warning::
@@ -412,7 +413,10 @@ class SpatialMappingMixin(AnalysisMixin[K, B]):
 
             - ``'pearson'`` - `Pearson correlation <https://en.wikipedia.org/wiki/Pearson_correlation_coefficient>`_.
             - ``'spearman'`` - `Spearman's rank correlation
-              <https://en.wikipedia.org/wiki/Spearman%27s_rank_correlation_coefficient>`_.
+                <https://en.wikipedia.org/wiki/Spearman%27s_rank_correlation_coefficient>`_.
+
+        groupby
+            Optional `obs` field in `AnnData` to compute correlations over categorical groups.
 
         device
             Device where to transfer the solutions, see :meth:`~moscot.base.output.BaseSolverOutput.to`.
@@ -436,19 +440,45 @@ class SpatialMappingMixin(AnalysisMixin[K, B]):
         if sp.issparse(gexp_sc):
             gexp_sc = gexp_sc.A
 
-        corrs = {}
+        corrs = {}  # type: ignore
         for key, val in self.solutions.items():
-            index_obs: List[Union[bool, int]] = (
-                self.adata_sp.obs[self._policy.key] == key[0]
+
+            # create mask corresponding to the current batch of spatial data
+            index_obs = (
+                (self.adata_sp.obs[self._policy.key] == key[0])
                 if self._policy.key is not None
                 else np.arange(self.adata_sp.shape[0])
             )
-            gexp_sp = self.adata_sp[index_obs, var_sc].X
+            adata_sp = self.adata_sp[index_obs, var_sc]
+
+            # initialize a dict of group masks
+            if groupby:
+                groups = adata_sp.obs[groupby].cat.categories
+                group_masks = {group: adata_sp.obs[groupby] == group for group in groups}
+                corrs[key] = {}
+            else:
+                group_masks = {"all": np.ones(adata_sp.shape[0], dtype=bool)}
+
+            gexp_sp = adata_sp.X
             if sp.issparse(gexp_sp):
                 gexp_sp = gexp_sp.A
+
+            # predict spatial feature expression
             gexp_pred_sp = val.to(device=device).pull(gexp_sc, scale_by_marginals=True)
-            corr_val = [corr(gexp_pred_sp[:, gi], gexp_sp[:, gi])[0] for gi, _ in enumerate(var_sc)]
-            corrs[key] = pd.Series(corr_val, index=var_sc)
+
+            # loop over groups and compute correlations
+            for group, group_mask in group_masks.items():
+                if np.sum(group_mask) < 2:
+                    logger.debug(f"Skipping `group={group}` as it contains less then 2 samples.")
+                    continue
+
+                corr_val = [
+                    corr(gexp_pred_sp[group_mask, gi], gexp_sp[group_mask, gi])[0] for gi, _ in enumerate(var_sc)
+                ]
+                if groupby:
+                    corrs[key][group] = pd.Series(corr_val, index=var_sc)
+                else:
+                    corrs[key] = pd.Series(corr_val, index=var_sc)
 
         return corrs
 

--- a/src/moscot/problems/space/_mixins.py
+++ b/src/moscot/problems/space/_mixins.py
@@ -475,10 +475,10 @@ class SpatialMappingMixin(AnalysisMixin[K, B]):
 
         # this is a bit hacky, I materialize the solution here
         predictions = []
-        for val in self.problems.values():
-            val.solution.to(device=device)
-            val.set_solution(np.array(val.solution.transport_matrix), overwrite=True)
-            predictions.append(val.pull(gexp_sc, scale_by_marginals=True))
+        for problem, solution in zip(self.problems.values(), self.solutions.values()):
+            solution.to(device=device)
+            problem.set_solution(np.array(solution.transport_matrix), overwrite=True)
+            predictions.append(solution.pull(gexp_sc, scale_by_marginals=True))
 
         adata_pred = AnnData(np.nan_to_num(np.vstack(predictions), nan=0.0, copy=False))
         adata_pred.obs_names = self.adata_sp.obs_names

--- a/src/moscot/problems/space/_mixins.py
+++ b/src/moscot/problems/space/_mixins.py
@@ -551,17 +551,13 @@ class SpatialMappingMixin(AnalysisMixin[K, B]):
             adata: AnnData,
             attr: Optional[Dict[str, Any]] = None,
         ) -> ArrayLike:
-            if attr is None:
-                return adata.X
+            attr = {"attr": "X"} if attr is None else attr
+            att = attr.get("attr", None)
+            key = attr.get("key", None)
 
-            main_attr, key = next(iter(attr.items()))
-
-            if hasattr(adata, main_attr):
-                attr_data = getattr(adata, main_attr)
-                if key in attr_data:
-                    return attr_data[key]
-
-            raise ValueError(f"Attribute {attr} not found in AnnData object.")
+            if key is not None:
+                return getattr(adata, att)[key]
+            return getattr(adata, att)
 
         if self.batch_key is None:
             spatial = self.adata.obsm[self.spatial_key]

--- a/src/moscot/problems/space/_mixins.py
+++ b/src/moscot/problems/space/_mixins.py
@@ -530,13 +530,17 @@ class SpatialMappingMixin(AnalysisMixin[K, B]):
             adata: AnnData,
             attr: Optional[Dict[str, Any]] = None,
         ) -> ArrayLike:
-            attr = {"attr": "X"} if attr is None else attr
-            att = attr.get("attr", None)
-            key = attr.get("key", None)
+            if attr is None:
+                return adata.X
 
-            if key is not None:
-                return getattr(adata, att)[key]
-            return getattr(adata, att)
+            main_attr, key = next(iter(attr.items()))
+
+            if hasattr(adata, main_attr):
+                attr_data = getattr(adata, main_attr)
+                if key in attr_data:
+                    return attr_data[key]
+
+            raise ValueError(f"Attribute {attr} not found in AnnData object.")
 
         if self.batch_key is None:
             spatial = self.adata.obsm[self.spatial_key]

--- a/src/moscot/problems/space/_mixins.py
+++ b/src/moscot/problems/space/_mixins.py
@@ -398,7 +398,7 @@ class SpatialMappingMixin(AnalysisMixin[K, B]):
         corr_method: Literal["pearson", "spearman"] = "pearson",
         device: Optional[Device_t] = None,
         groupby: Optional[str] = None,
-    ) -> Mapping[Any, Mapping[Tuple[K, K], pd.Series]]:
+    ) -> Union[Mapping[Tuple[K, K], Mapping[Any, pd.Series]], Mapping[Tuple[K, K], pd.Series]]:
         """Correlate true and predicted gene expression.
 
         .. warning::


### PR DESCRIPTION
This introduces a `LinearSpatialMapping` problem which is mean for mapping in spatially-aware latent spaces (think about e.g. NicheCompass latent spaces). Thus, spatial information is already contained in latent dimensions and does not need to be supplied externally via a quadratic term. This reduces time complexity, memory complexity, and the number of tunable parameters. 

The current implementation is naive, I just copied the `SpatialMapping` problem and adapted the `prepare` and `solve` methods. What would be a better abstraction in your opinion @giovp? We could do it like you @MUCDK did for the Temporal/Lineage problems, i.e. have the quadratic problem inherit from the linear one, or we could also do it the other way round. Do you prefer any of these possibilities? Or something else?

This PR also introduces a `groupby` parameter for gene correlation computation, which is useful when you're interested in correlation over specific groups, like clusters etc. 

I'll add tests once I hear your general thoughts on this - I'm happy to adapt this to your requirements. 