### PR TITLE
Remove skip markers for balanced since LR criterion is fixed

### DIFF
--- a/tests/problems/space/test_alignment_problem.py
+++ b/tests/problems/space/test_alignment_problem.py
@@ -75,7 +75,6 @@ class TestAlignmentProblem:
             assert ref == reference
             assert isinstance(ap[prob_key], ap._base_problem_type)
 
-    @pytest.mark.skip(reason="See https://github.com/theislab/moscot/issues/678")
     @pytest.mark.parametrize(
         ("epsilon", "alpha", "rank", "initializer"),
         [(1, 0.9, -1, None), (1, 0.5, 10, "random"), (1, 0.5, 10, "rank2"), (0.1, 0.1, -1, None)],

--- a/tests/problems/space/test_mapping_problem.py
+++ b/tests/problems/space/test_mapping_problem.py
@@ -94,7 +94,6 @@ class TestMappingProblem:
             assert prob.x.data_src.shape == (n_obs, x_n_var)
             assert prob.y.data_src.shape == (n_obs, y_n_var)
 
-    @pytest.mark.skip(reason="See https://github.com/theislab/moscot/issues/678")
     @pytest.mark.parametrize(
         ("epsilon", "alpha", "rank", "initializer"),
         [(1e-2, 0.9, -1, None), (2, 0.5, 10, "random"), (2, 0.5, 10, "rank2"), (2, 0.1, -1, None)],


### PR DESCRIPTION
After this https://github.com/ott-jax/ott/pull/547#event-13382808561 we can finally expect the tests to pass again. So the skip markers are removed.

Closes:
- https://github.com/theislab/moscot/issues/678
- https://github.com/theislab/moscot/issues/703

