### PR TITLE
Introduce a `groupby` attribute for correlation computation

### DIFF
--- a/src/moscot/problems/space/_mixins.py
+++ b/src/moscot/problems/space/_mixins.py
@@ -454,7 +454,7 @@ class SpatialMappingMixin(AnalysisMixin[K, B]):
             # initialize a dict of group masks
             if groupby:
                 groups = adata_sp.obs[groupby].cat.categories
-                group_masks = {group: adata_sp.obs[groupby] == group for group in groups}
+                group_masks = {group: (adata_sp.obs[groupby]).values == group for group in groups}
                 corrs[key] = {}
             else:
                 group_masks = {"all": np.ones(adata_sp.shape[0], dtype=bool)}
@@ -472,6 +472,7 @@ class SpatialMappingMixin(AnalysisMixin[K, B]):
                     logger.debug(f"Skipping `group={group}` as it contains less then 2 samples.")
                     continue
 
+                # import pdb; pdb.set_trace()
                 corr_val = [
                     corr(gexp_pred_sp[group_mask, gi], gexp_sp[group_mask, gi])[0] for gi, _ in enumerate(var_sc)
                 ]

--- a/src/moscot/problems/space/_mixins.py
+++ b/src/moscot/problems/space/_mixins.py
@@ -414,10 +414,8 @@ class SpatialMappingMixin(AnalysisMixin[K, B]):
             - ``'pearson'`` - `Pearson correlation <https://en.wikipedia.org/wiki/Pearson_correlation_coefficient>`_.
             - ``'spearman'`` - `Spearman's rank correlation
                 <https://en.wikipedia.org/wiki/Spearman%27s_rank_correlation_coefficient>`_.
-
         groupby
             Optional `obs` field in `AnnData` to compute correlations over categorical groups.
-
         device
             Device where to transfer the solutions, see :meth:`~moscot.base.output.BaseSolverOutput.to`.
 
@@ -440,7 +438,7 @@ class SpatialMappingMixin(AnalysisMixin[K, B]):
         if sp.issparse(gexp_sc):
             gexp_sc = gexp_sc.toarray()
 
-        corrs = {}  # type: ignore
+        corrs: Union[Dict[Tuple[K, K], Dict[Any, pd.Series]], Dict[Tuple[K, K], pd.Series]] = {}
         for key, val in self.solutions.items():
 
             # create mask corresponding to the current batch of spatial data
@@ -472,7 +470,6 @@ class SpatialMappingMixin(AnalysisMixin[K, B]):
                     logger.debug(f"Skipping `group={group}` as it contains less then 2 samples.")
                     continue
 
-                # import pdb; pdb.set_trace()
                 corr_val = [
                     corr(gexp_pred_sp[group_mask, gi], gexp_sp[group_mask, gi])[0] for gi, _ in enumerate(var_sc)
                 ]

--- a/src/moscot/problems/space/_mixins.py
+++ b/src/moscot/problems/space/_mixins.py
@@ -398,7 +398,7 @@ class SpatialMappingMixin(AnalysisMixin[K, B]):
         corr_method: Literal["pearson", "spearman"] = "pearson",
         device: Optional[Device_t] = None,
         groupby: Optional[str] = None,
-    ) -> Mapping[Any, Mapping[Tuple[K, K], pd.Series]]:
+    ) -> Union[Mapping[Tuple[K, K], Mapping[Any, pd.Series]], Mapping[Tuple[K, K], pd.Series]]:
         """Correlate true and predicted gene expression.
 
         .. warning::
@@ -464,7 +464,7 @@ class SpatialMappingMixin(AnalysisMixin[K, B]):
                 gexp_sp = gexp_sp.toarray()
 
             # predict spatial feature expression
-            gexp_pred_sp = val.pull(gexp_sc, scale_by_marginals=True)
+            gexp_pred_sp = val.to(device=device).pull(gexp_sc, scale_by_marginals=True)
 
             # loop over groups and compute correlations
             for group, group_mask in group_masks.items():

--- a/src/moscot/problems/space/_mixins.py
+++ b/src/moscot/problems/space/_mixins.py
@@ -396,7 +396,9 @@ class SpatialMappingMixin(AnalysisMixin[K, B]):
         self: SpatialMappingMixinProtocol[K, B],
         var_names: Optional[Sequence[str]] = None,
         corr_method: Literal["pearson", "spearman"] = "pearson",
-    ) -> Mapping[Tuple[K, K], pd.Series]:
+        device: Optional[Device_t] = None,
+        groupby: Optional[str] = None,
+    ) -> Mapping[Any, Mapping[Tuple[K, K], pd.Series]]:
         """Correlate true and predicted gene expression.
 
         .. warning::
@@ -411,7 +413,13 @@ class SpatialMappingMixin(AnalysisMixin[K, B]):
 
             - ``'pearson'`` - `Pearson correlation <https://en.wikipedia.org/wiki/Pearson_correlation_coefficient>`_.
             - ``'spearman'`` - `Spearman's rank correlation
-              <https://en.wikipedia.org/wiki/Spearman%27s_rank_correlation_coefficient>`_.
+                <https://en.wikipedia.org/wiki/Spearman%27s_rank_correlation_coefficient>`_.
+
+        groupby
+            Optional `obs` field in `AnnData` to compute correlations over categorical groups.
+
+        device
+            Device where to transfer the solutions, see :meth:`~moscot.base.output.BaseSolverOutput.to`.
 
         Returns
         -------
@@ -432,19 +440,45 @@ class SpatialMappingMixin(AnalysisMixin[K, B]):
         if sp.issparse(gexp_sc):
             gexp_sc = gexp_sc.toarray()
 
-        corrs = {}
+        corrs = {}  # type: ignore
         for key, val in self.solutions.items():
-            index_obs: List[Union[bool, int]] = (
-                self.adata_sp.obs[self._policy.key] == key[0]
+
+            # create mask corresponding to the current batch of spatial data
+            index_obs = (
+                (self.adata_sp.obs[self._policy.key] == key[0])
                 if self._policy.key is not None
                 else np.arange(self.adata_sp.shape[0])
             )
-            gexp_sp = self.adata_sp[index_obs, var_sc].X
+            adata_sp = self.adata_sp[index_obs, var_sc]
+
+            # initialize a dict of group masks
+            if groupby:
+                groups = adata_sp.obs[groupby].cat.categories
+                group_masks = {group: adata_sp.obs[groupby] == group for group in groups}
+                corrs[key] = {}
+            else:
+                group_masks = {"all": np.ones(adata_sp.shape[0], dtype=bool)}
+
+            gexp_sp = adata_sp.X
             if sp.issparse(gexp_sp):
                 gexp_sp = gexp_sp.toarray()
+
+            # predict spatial feature expression
             gexp_pred_sp = val.pull(gexp_sc, scale_by_marginals=True)
-            corr_val = [corr(gexp_pred_sp[:, gi], gexp_sp[:, gi])[0] for gi, _ in enumerate(var_sc)]
-            corrs[key] = pd.Series(corr_val, index=var_sc)
+
+            # loop over groups and compute correlations
+            for group, group_mask in group_masks.items():
+                if np.sum(group_mask) < 2:
+                    logger.debug(f"Skipping `group={group}` as it contains less then 2 samples.")
+                    continue
+
+                corr_val = [
+                    corr(gexp_pred_sp[group_mask, gi], gexp_sp[group_mask, gi])[0] for gi, _ in enumerate(var_sc)
+                ]
+                if groupby:
+                    corrs[key][group] = pd.Series(corr_val, index=var_sc)
+                else:
+                    corrs[key] = pd.Series(corr_val, index=var_sc)
 
         return corrs
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -185,7 +185,7 @@ def adata_space_rotate() -> AnnData:
 @pytest.fixture()
 def adata_mapping() -> AnnData:
     grid = _make_grid(10)
-    adataref, adata1, adata2 = _make_adata(grid, n=3, seed=17)
+    adataref, adata1, adata2 = _make_adata(grid, n=3, seed=17, cat_key="covariate", num_categories=3)
     sc.pp.pca(adataref, n_comps=30)
     return ad.concat([adataref, adata1, adata2], label="batch", join="outer", index_unique="-")
 

--- a/tests/problems/space/test_mixins.py
+++ b/tests/problems/space/test_mixins.py
@@ -127,18 +127,25 @@ class TestSpatialAlignmentAnalysisMixin:
 class TestSpatialMappingAnalysisMixin:
     @pytest.mark.parametrize("sc_attr", [{"attr": "X"}, {"attr": "obsm", "key": "X_pca"}])
     @pytest.mark.parametrize("var_names", ["0", [str(i) for i in range(20)]])
+    @pytest.mark.parametrize("groupby", [None, "covariate"])
     def test_analysis(
         self,
         adata_mapping: AnnData,
         sc_attr: Dict[str, str],
         var_names: Optional[List[Optional[str]]],
+        groupby: Optional[str],
     ):
         adataref, adatasp = _adata_spatial_split(adata_mapping)
         mp = MappingProblem(adataref, adatasp).prepare(batch_key="batch", sc_attr=sc_attr).solve()
 
-        corr = mp.correlate(var_names)
+        corr = mp.correlate(var_names, groupby=groupby)
         imp = mp.impute()
-        pd.testing.assert_series_equal(*list(corr.values()))
+
+        if groupby:
+            for key in adata_mapping.obs[groupby].cat.categories:
+                pd.testing.assert_series_equal(*[corr[problem][key] for problem in corr])
+        else:
+            pd.testing.assert_series_equal(*list(corr.values()))
         assert imp.shape == adatasp.shape
 
     def test_correspondence(


### PR DESCRIPTION
This introduces a `groupby` parameter for `mapping_problem.correlate()` to evaluate Pearson/Spearmann correlation over groups of cells. I've also adapted tests slightly to cover this case. 