### PR TITLE
Fix/spatial mixins

### DIFF
--- a/src/moscot/problems/space/_mixins.py
+++ b/src/moscot/problems/space/_mixins.py
@@ -466,7 +466,8 @@ class SpatialMappingMixin(AnalysisMixin[K, B]):
                 gexp_sp = gexp_sp.toarray()
 
             # predict spatial feature expression
-            n_splits = np.floor(gexp_sc.shape[1] / batch_size) if batch_size else 1
+            n_splits = np.max([np.floor(gexp_sc.shape[1] / batch_size), 1]) if batch_size else 1
+            logger.debug(f"Processing {gexp_sc.shape[1]} features in {n_splits} batches.")
             gexp_pred_sp = np.hstack(
                 [
                     val.to(device=device).pull(x, scale_by_marginals=True)
@@ -520,7 +521,8 @@ class SpatialMappingMixin(AnalysisMixin[K, B]):
             gexp_sc = gexp_sc.toarray()
 
         # predict spatial feature expression
-        n_splits = np.floor(gexp_sc.shape[1] / batch_size) if batch_size else 1
+        n_splits = np.max([np.floor(gexp_sc.shape[1] / batch_size), 1]) if batch_size else 1
+        logger.debug(f"Processing {gexp_sc.shape[1]} features in {n_splits} batches.")
         predictions = [
             np.hstack(
                 [

--- a/src/moscot/problems/space/_mixins.py
+++ b/src/moscot/problems/space/_mixins.py
@@ -418,7 +418,7 @@ class SpatialMappingMixin(AnalysisMixin[K, B]):
         device
             Device where to transfer the solutions, see :meth:`~moscot.base.output.BaseSolverOutput.to`.
         groupby
-            Optional `obs` field in `AnnData` to compute correlations over categorical groups.
+            Optional key in :attr:`~anndata.AnnData.obs`, containing categorical annotations for grouping.
         batch_size:
             Number of features to process at once. If :obj:`None`, process all features at once.
             Larger values will require more memory.

--- a/tests/problems/space/test_mixins.py
+++ b/tests/problems/space/test_mixins.py
@@ -128,18 +128,20 @@ class TestSpatialMappingAnalysisMixin:
     @pytest.mark.parametrize("sc_attr", [{"attr": "X"}, {"attr": "obsm", "key": "X_pca"}])
     @pytest.mark.parametrize("var_names", ["0", [str(i) for i in range(20)]])
     @pytest.mark.parametrize("groupby", [None, "covariate"])
+    @pytest.mark.parametrize("batch_size", [None, 7, 10, 100])
     def test_analysis(
         self,
         adata_mapping: AnnData,
         sc_attr: Dict[str, str],
         var_names: Optional[List[Optional[str]]],
         groupby: Optional[str],
+        batch_size: Optional[int],
     ):
         adataref, adatasp = _adata_spatial_split(adata_mapping)
         mp = MappingProblem(adataref, adatasp).prepare(batch_key="batch", sc_attr=sc_attr).solve()
 
-        corr = mp.correlate(var_names, groupby=groupby)
-        imp = mp.impute()
+        corr = mp.correlate(var_names, groupby=groupby, batch_size=batch_size)
+        imp = mp.impute(batch_size=batch_size)
 
         if groupby:
             for key in adata_mapping.obs[groupby].cat.categories:


### PR DESCRIPTION
This implements a batched mode for `correlate` and `impute`, offering a temporary fix for https://github.com/theislab/moscot/issues/729. 