### PR TITLE
Fix sankey threshold

### DIFF
--- a/src/moscot/problems/time/_mixins.py
+++ b/src/moscot/problems/time/_mixins.py
@@ -379,7 +379,7 @@ class TemporalMixin(AnalysisMixin[K, B]):
             cell_transitions_updated = cell_transitions
 
         if threshold is not None:
-            for ct in cell_transitions:
+            for ct in cell_transitions_updated:
                 ct[ct < threshold] = 0.0
 
         if key_added is None:


### PR DESCRIPTION
@753

Fixes the threshold argument in `TemporalProblem.sankey`

Before:
![sankey_without_th](https://github.com/user-attachments/assets/22b201b0-7b95-450c-8558-a0600f573c00)
After:
![sankey_with_th_ 05](https://github.com/user-attachments/assets/fe1ef22e-64b5-48cc-8dfd-75d5b76596a4)
