### PR TITLE
Refactor/remove protocol classes

### DIFF
--- a/src/moscot/base/problems/_mixins.py
+++ b/src/moscot/base/problems/_mixins.py
@@ -11,7 +11,6 @@ from typing import (
     Literal,
     Mapping,
     Optional,
-    Protocol,
     Sequence,
     Union,
 )
@@ -21,11 +20,9 @@ import pandas as pd
 from scipy.sparse.linalg import LinearOperator
 
 import scanpy as sc
-from anndata import AnnData
 
 from moscot import _constants
 from moscot._types import ArrayLike, Numeric_t, Str_Dict_t
-from moscot.base.output import BaseDiscreteSolverOutput
 from moscot.base.problems._utils import (
     _check_argument_compatibility_cell_transition,
     _correlation_test,
@@ -34,92 +31,12 @@ from moscot.base.problems._utils import (
     _validate_annotations,
     _validate_args_cell_transition,
 )
-from moscot.base.problems.compound_problem import ApplyOutput_t, B, K
+from moscot.base.problems.compound_problem import B, K
 from moscot.plotting._utils import set_plotting_vars
 from moscot.utils.data import transcription_factors
 from moscot.utils.subset_policy import SubsetPolicy
 
 __all__ = ["AnalysisMixin"]
-
-
-class AnalysisMixinProtocol(Protocol[K, B]):
-    """Protocol class."""
-
-    adata: AnnData
-    _policy: SubsetPolicy[K]
-    solutions: dict[tuple[K, K], BaseDiscreteSolverOutput]
-    problems: dict[tuple[K, K], B]
-
-    def _apply(
-        self,
-        data: Optional[Union[str, ArrayLike]] = None,
-        source: Optional[K] = None,
-        target: Optional[K] = None,
-        forward: bool = True,
-        return_all: bool = False,
-        scale_by_marginals: bool = False,
-        **kwargs: Any,
-    ) -> ApplyOutput_t[K]: ...
-
-    def _interpolate_transport(
-        self: AnalysisMixinProtocol[K, B],
-        path: Sequence[tuple[K, K]],
-        scale_by_marginals: bool = True,
-    ) -> LinearOperator: ...
-
-    def _flatten(
-        self: AnalysisMixinProtocol[K, B],
-        data: dict[K, ArrayLike],
-        *,
-        key: Optional[str],
-    ) -> ArrayLike: ...
-
-    def push(self, *args: Any, **kwargs: Any) -> Optional[ApplyOutput_t[K]]:
-        """Push distribution."""
-        ...
-
-    def pull(self, *args: Any, **kwargs: Any) -> Optional[ApplyOutput_t[K]]:
-        """Pull distribution."""
-        ...
-
-    def _cell_transition(
-        self: AnalysisMixinProtocol[K, B],
-        source: K,
-        target: K,
-        source_groups: Str_Dict_t,
-        target_groups: Str_Dict_t,
-        aggregation_mode: Literal["annotation", "cell"] = "annotation",
-        key_added: Optional[str] = _constants.CELL_TRANSITION,
-        **kwargs: Any,
-    ) -> pd.DataFrame: ...
-
-    def _cell_transition_online(
-        self: AnalysisMixinProtocol[K, B],
-        key: Optional[str],
-        source: K,
-        target: K,
-        source_groups: Str_Dict_t,
-        target_groups: Str_Dict_t,
-        forward: bool = False,  # return value will be row-stochastic if forward=True, else column-stochastic
-        aggregation_mode: Literal["annotation", "cell"] = "annotation",
-        other_key: Optional[str] = None,
-        other_adata: Optional[str] = None,
-        batch_size: Optional[int] = None,
-        normalize: bool = True,
-    ) -> pd.DataFrame: ...
-
-    def _annotation_mapping(
-        self: AnalysisMixinProtocol[K, B],
-        mapping_mode: Literal["sum", "max"],
-        annotation_label: str,
-        forward: bool,
-        source: K,
-        target: K,
-        key: str | None = None,
-        other_adata: Optional[str] = None,
-        scale_by_marginals: bool = True,
-        cell_transition_kwargs: Mapping[str, Any] = types.MappingProxyType({}),
-    ) -> pd.DataFrame: ...
 
 
 class AnalysisMixin(Generic[K, B]):
@@ -129,7 +46,7 @@ class AnalysisMixin(Generic[K, B]):
         super().__init__(*args, **kwargs)
 
     def _cell_transition(
-        self: AnalysisMixinProtocol[K, B],
+        self,
         source: K,
         target: K,
         source_groups: Str_Dict_t,
@@ -178,7 +95,7 @@ class AnalysisMixin(Generic[K, B]):
         return tm
 
     def _annotation_aggregation_transition(
-        self: AnalysisMixinProtocol[K, B],
+        self,
         annotations_1: list[Any],
         annotations_2: list[Any],
         df: pd.DataFrame,
@@ -210,7 +127,7 @@ class AnalysisMixin(Generic[K, B]):
         )
 
     def _cell_transition_online(
-        self: AnalysisMixinProtocol[K, B],
+        self,
         key: Optional[str],
         source: K,
         target: K,
@@ -309,7 +226,7 @@ class AnalysisMixin(Generic[K, B]):
         )
 
     def _annotation_mapping(
-        self: AnalysisMixinProtocol[K, B],
+        self,
         mapping_mode: Literal["sum", "max"],
         annotation_label: str,
         source: K,
@@ -394,7 +311,7 @@ class AnalysisMixin(Generic[K, B]):
         raise NotImplementedError(f"Mapping mode `{mapping_mode!r}` is not yet implemented.")
 
     def _sample_from_tmap(
-        self: AnalysisMixinProtocol[K, B],
+        self,
         source: K,
         target: K,
         n_samples: int,
@@ -472,7 +389,7 @@ class AnalysisMixin(Generic[K, B]):
         return rows, all_cols_sampled  # type: ignore[return-value]
 
     def _interpolate_transport(
-        self: AnalysisMixinProtocol[K, B],
+        self,
         # TODO(@giovp): rename this to 'explicit_steps', pass to policy.plan() and reintroduce (source_key, target_key)
         path: Sequence[tuple[K, K]],
         scale_by_marginals: bool = True,
@@ -485,7 +402,7 @@ class AnalysisMixin(Generic[K, B]):
         fst, *rest = path
         return self.solutions[fst].chain([self.solutions[r] for r in rest], scale_by_marginals=scale_by_marginals)
 
-    def _flatten(self: AnalysisMixinProtocol[K, B], data: dict[K, ArrayLike], *, key: Optional[str]) -> ArrayLike:
+    def _flatten(self, data: dict[K, ArrayLike], *, key: Optional[str]) -> ArrayLike:
         tmp = np.full(len(self.adata), np.nan)
         for k, v in data.items():
             mask = self.adata.obs[key] == k
@@ -493,7 +410,7 @@ class AnalysisMixin(Generic[K, B]):
         return tmp
 
     def _cell_aggregation_transition(
-        self: AnalysisMixinProtocol[K, B],
+        self,
         df_from: pd.DataFrame,
         df_to: pd.DataFrame,
         annotations: list[Any],
@@ -540,7 +457,7 @@ class AnalysisMixin(Generic[K, B]):
     # adapted from:
     # https://github.com/theislab/cellrank/blob/master/cellrank/_utils/_utils.py#L392
     def compute_feature_correlation(
-        self: AnalysisMixinProtocol[K, B],
+        self,
         obs_key: str,
         corr_method: Literal["pearson", "spearman"] = "pearson",
         significance_method: Literal["fisher", "perm_test"] = "fisher",
@@ -649,7 +566,7 @@ class AnalysisMixin(Generic[K, B]):
         )
 
     def compute_entropy(
-        self: AnalysisMixinProtocol[K, B],
+        self,
         source: K,
         target: K,
         forward: bool = True,

--- a/src/moscot/base/problems/_mixins.py
+++ b/src/moscot/base/problems/_mixins.py
@@ -32,6 +32,10 @@ from moscot.base.problems._utils import (
     _validate_args_cell_transition,
 )
 from moscot.base.problems.compound_problem import B, K
+from moscot.base.problems.problem import (
+    AbstractPushPullAdata,
+    AbstractSolutionsProblems,
+)
 from moscot.plotting._utils import set_plotting_vars
 from moscot.utils.data import transcription_factors
 from moscot.utils.subset_policy import SubsetPolicy
@@ -39,7 +43,7 @@ from moscot.utils.subset_policy import SubsetPolicy
 __all__ = ["AnalysisMixin"]
 
 
-class AnalysisMixin(Generic[K, B]):
+class AnalysisMixin(Generic[K, B], AbstractPushPullAdata, AbstractSolutionsProblems):
     """Base Analysis Mixin."""
 
     def __init__(self, *args: Any, **kwargs: Any):
@@ -48,7 +52,7 @@ class AnalysisMixin(Generic[K, B]):
     def _cell_transition(
         self,
         source: K,
-        target: K,
+        target: Optional[K],
         source_groups: Str_Dict_t,
         target_groups: Str_Dict_t,
         aggregation_mode: Literal["annotation", "cell"] = "annotation",
@@ -130,7 +134,7 @@ class AnalysisMixin(Generic[K, B]):
         self,
         key: Optional[str],
         source: K,
-        target: K,
+        target: Optional[K],
         source_groups: Str_Dict_t,
         target_groups: Str_Dict_t,
         forward: bool = False,  # return value will be row-stochastic if forward=True, else column-stochastic
@@ -189,7 +193,7 @@ class AnalysisMixin(Generic[K, B]):
                 split_mass=False,
                 **move_op_const_kwargs,
             )
-            tm = self._annotation_aggregation_transition(  # type: ignore[attr-defined]
+            tm = self._annotation_aggregation_transition(
                 annotations_1=source_annotations_verified if forward else target_annotations_verified,
                 annotations_2=target_annotations_verified if forward else source_annotations_verified,
                 df=df_to,
@@ -203,7 +207,7 @@ class AnalysisMixin(Generic[K, B]):
                 split_mass=True,
                 **move_op_const_kwargs,
             )
-            tm = self._cell_aggregation_transition(  # type: ignore[attr-defined]
+            tm = self._cell_aggregation_transition(
                 df_from=df_from,
                 df_to=df_to,
                 annotations=target_annotations_verified if forward else source_annotations_verified,
@@ -623,7 +627,7 @@ class AnalysisMixin(Generic[K, B]):
                 split_mass=True,
                 key_added=None,
             )
-            df.iloc[range(batch, min(batch + batch_size, len(df))), 0] = stats.entropy(cond_dists + c, **kwargs)  # type: ignore[operator]
+            df.iloc[range(batch, min(batch + batch_size, len(df))), 0] = stats.entropy(cond_dists + c, **kwargs)
         if key_added is not None:
             self.adata.obs[key_added] = df
         return df if key_added is None else None

--- a/src/moscot/base/problems/birth_death.py
+++ b/src/moscot/base/problems/birth_death.py
@@ -8,13 +8,13 @@ from anndata import AnnData
 
 from moscot._logging import logger
 from moscot._types import ArrayLike
-from moscot.base.problems.problem import OTProblem
+from moscot.base.problems.problem import AbstractAdataAccess, OTProblem
 from moscot.utils.data import apoptosis_markers, proliferation_markers
 
 __all__ = ["BirthDeathProblem", "BirthDeathMixin"]
 
 
-class BirthDeathMixin:
+class BirthDeathMixin(AbstractAdataAccess):
     """Mixin class used to estimate cell proliferation and apoptosis.
 
     Parameters
@@ -88,7 +88,7 @@ class BirthDeathMixin:
                 "At least one of `gene_set_proliferation` or `gene_set_apoptosis` must be provided to score genes."
             )
 
-        return self  # type: ignore[return-value]
+        return self
 
     @property
     def proliferation_key(self) -> Optional[str]:

--- a/src/moscot/base/problems/birth_death.py
+++ b/src/moscot/base/problems/birth_death.py
@@ -1,14 +1,5 @@
 from functools import partial
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    Literal,
-    Optional,
-    Protocol,
-    Sequence,
-    Union,
-)
+from typing import TYPE_CHECKING, Any, Callable, Literal, Optional, Sequence, Union
 
 import numpy as np
 
@@ -21,32 +12,6 @@ from moscot.base.problems.problem import OTProblem
 from moscot.utils.data import apoptosis_markers, proliferation_markers
 
 __all__ = ["BirthDeathProblem", "BirthDeathMixin"]
-
-
-class BirthDeathProtocol(Protocol):  # noqa: D101
-    adata: AnnData
-    proliferation_key: Optional[str]
-    apoptosis_key: Optional[str]
-    _proliferation_key: Optional[str]
-    _apoptosis_key: Optional[str]
-    _scaling: float
-    _prior_growth: Optional[ArrayLike]
-
-    def score_genes_for_marginals(  # noqa: D102
-        self: "BirthDeathProtocol",
-        gene_set_proliferation: Optional[Union[Literal["human", "mouse"], Sequence[str]]] = None,
-        gene_set_apoptosis: Optional[Union[Literal["human", "mouse"], Sequence[str]]] = None,
-        proliferation_key: str = "proliferation",
-        apoptosis_key: str = "apoptosis",
-        **kwargs: Any,
-    ) -> "BirthDeathProtocol": ...
-
-
-class BirthDeathProblemProtocol(BirthDeathProtocol, Protocol):  # noqa: D101
-    delta: float
-    adata_tgt: AnnData
-    a: Optional[ArrayLike]
-    b: Optional[ArrayLike]
 
 
 class BirthDeathMixin:
@@ -68,7 +33,7 @@ class BirthDeathMixin:
         self._prior_growth: Optional[ArrayLike] = None
 
     def score_genes_for_marginals(
-        self,  # type: BirthDeathProblemProtocol
+        self,
         gene_set_proliferation: Optional[Union[Literal["human", "mouse"], Sequence[str]]] = None,
         gene_set_apoptosis: Optional[Union[Literal["human", "mouse"], Sequence[str]]] = None,
         proliferation_key: str = "proliferation",
@@ -131,7 +96,7 @@ class BirthDeathMixin:
         return self._proliferation_key
 
     @proliferation_key.setter
-    def proliferation_key(self: BirthDeathProtocol, key: Optional[str]) -> None:
+    def proliferation_key(self, key: Optional[str]) -> None:
         if key is not None and key not in self.adata.obs:
             raise KeyError(f"Unable to find proliferation data in `adata.obs[{key!r}]`.")
         self._proliferation_key = key
@@ -142,7 +107,7 @@ class BirthDeathMixin:
         return self._apoptosis_key
 
     @apoptosis_key.setter
-    def apoptosis_key(self: BirthDeathProtocol, key: Optional[str]) -> None:
+    def apoptosis_key(self, key: Optional[str]) -> None:
         if key is not None and key not in self.adata.obs:
             raise KeyError(f"Unable to find apoptosis data in `adata.obs[{key!r}]`.")
         self._apoptosis_key = key
@@ -161,7 +126,7 @@ class BirthDeathProblem(BirthDeathMixin, OTProblem):
     """  # noqa: D205
 
     def estimate_marginals(
-        self,  # type: BirthDeathProblemProtocol
+        self,
         adata: AnnData,
         source: bool,
         proliferation_key: Optional[str] = None,

--- a/src/moscot/base/problems/compound_problem.py
+++ b/src/moscot/base/problems/compound_problem.py
@@ -47,7 +47,7 @@ Callback_t = Callable[[Literal["xy", "x", "y"], AnnData, Optional[AnnData]], Opt
 ApplyOutput_t = Union[ArrayLike, Dict[K, ArrayLike]]
 
 
-class BaseCompoundProblem(BaseProblem, abc.ABC, Generic[K, B]):
+class BaseCompoundProblem(BaseProblem, Generic[K, B], abc.ABC):
     """Base class for all biological problems.
 
     This class translates a biological problem to multiple :term:`OT` problems.

--- a/src/moscot/base/problems/problem.py
+++ b/src/moscot/base/problems/problem.py
@@ -1,6 +1,7 @@
 import abc
 import pathlib
 import types
+from abc import ABC, abstractmethod
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -220,6 +221,93 @@ class BaseProblem(abc.ABC, metaclass=CombinedMeta):
     def problem_kind(self) -> ProblemKind_t:
         """Kind of the underlying problem."""
         return self._problem_kind
+
+
+class AbstractAdataAccess(ABC, metaclass=CombinedMeta):
+
+    @property
+    @abstractmethod
+    def adata(self) -> AnnData:
+        """Annotated data object."""
+        pass
+
+
+class AbstractPushPullAdata(AbstractAdataAccess):
+
+    @abstractmethod
+    def pull(
+        self,
+        *args: Any,
+        **kwargs: Any,
+    ) -> Any:
+        pass
+
+    @abstractmethod
+    def push(
+        self,
+        *args: Any,
+        **kwargs: Any,
+    ) -> Any:
+        pass
+
+    @abstractmethod
+    def _apply(
+        self,
+        *args: Any,
+        **kwargs: Any,
+    ) -> Any:
+        pass
+
+
+class AbstractSolutionsProblems(ABC, metaclass=CombinedMeta):
+
+    @property
+    @abstractmethod
+    def solutions(self) -> Any:
+        """Solutions."""
+        pass
+
+    @property
+    @abstractmethod
+    def problems(self) -> Any:
+        """Problems."""
+        pass
+
+    @property
+    @abstractmethod
+    def _policy(self) -> Any:
+        """Subset policy."""
+        pass
+
+
+class AbstractSrcTgt(ABC, metaclass=CombinedMeta):
+
+    @property
+    @abstractmethod
+    def adata_src(self) -> AnnData:
+        """Annotated data object."""
+        pass
+
+    @property
+    @abstractmethod
+    def adata_tgt(self) -> AnnData:
+        """Annotated data object."""
+        pass
+
+
+class AbstractSpSc(ABC, metaclass=CombinedMeta):
+
+    @property
+    @abstractmethod
+    def adata_sp(self) -> AnnData:
+        """Annotated data object."""
+        pass
+
+    @property
+    @abstractmethod
+    def adata_sc(self) -> AnnData:
+        """Annotated data object."""
+        pass
 
 
 class OTProblem(BaseProblem):

--- a/src/moscot/problems/cross_modality/_mixins.py
+++ b/src/moscot/problems/cross_modality/_mixins.py
@@ -7,24 +7,10 @@ from anndata import AnnData
 
 from moscot import _constants
 from moscot._types import ArrayLike, Str_Dict_t
-from moscot.base.problems._mixins import AnalysisMixin, AnalysisMixinProtocol
+from moscot.base.problems._mixins import AnalysisMixin
 from moscot.base.problems.compound_problem import B, K
 
 __all__ = ["CrossModalityTranslationMixin"]
-
-
-class CrossModalityTranslationMixinProtocol(AnalysisMixinProtocol[K, B]):
-    """Protocol class."""
-
-    adata_src: AnnData
-    adata_tgt: AnnData
-    _src_attr: Optional[Dict[str, Any]]
-    _tgt_attr: Optional[Dict[str, Any]]
-    batch_key: Optional[str]
-
-    def _cell_transition(self: AnalysisMixinProtocol[K, B], *args: Any, **kwargs: Any) -> pd.DataFrame: ...
-
-    def _annotation_mapping(self: AnalysisMixinProtocol[K, B], *args: Any, **kwargs: Any) -> pd.DataFrame: ...
 
 
 class CrossModalityTranslationMixin(AnalysisMixin[K, B]):
@@ -37,7 +23,7 @@ class CrossModalityTranslationMixin(AnalysisMixin[K, B]):
         self._batch_key: Optional[str] = None
 
     def translate(  # type: ignore[misc]
-        self: CrossModalityTranslationMixinProtocol[K, B],
+        self,
         source: K,
         target: K,
         forward: bool = True,
@@ -107,7 +93,7 @@ class CrossModalityTranslationMixin(AnalysisMixin[K, B]):
         return prob.push(_get_features(adata_src, attr=src_attr), **kwargs)
 
     def cell_transition(  # type: ignore[misc]
-        self: CrossModalityTranslationMixinProtocol[K, B],
+        self,
         source: K,
         target: Optional[K] = None,
         source_groups: Optional[Str_Dict_t] = None,
@@ -186,7 +172,7 @@ class CrossModalityTranslationMixin(AnalysisMixin[K, B]):
         )
 
     def annotation_mapping(  # type: ignore[misc]
-        self: CrossModalityTranslationMixinProtocol[K, B],
+        self,
         mapping_mode: Literal["sum", "max"],
         annotation_label: str,
         forward: bool,

--- a/src/moscot/problems/cross_modality/_mixins.py
+++ b/src/moscot/problems/cross_modality/_mixins.py
@@ -210,7 +210,7 @@ class CrossModalityTranslationMixin(AnalysisMixin[K, B], AbstractSrcTgt):
         cell_transition_kwargs
             Keyword arguments for :meth:`cell_transition`, used only if ``mapping_mode = 'sum'``.
         scale_by_marginals
-            TODO
+            Whether to scale by the source/target :term:`marginals`.
 
 
         Returns

--- a/src/moscot/problems/cross_modality/_mixins.py
+++ b/src/moscot/problems/cross_modality/_mixins.py
@@ -210,7 +210,7 @@ class CrossModalityTranslationMixin(AnalysisMixin[K, B], AbstractSrcTgt):
         cell_transition_kwargs
             Keyword arguments for :meth:`cell_transition`, used only if ``mapping_mode = 'sum'``.
         scale_by_marginals
-            todo
+            TODO
 
 
         Returns
@@ -227,7 +227,7 @@ class CrossModalityTranslationMixin(AnalysisMixin[K, B], AbstractSrcTgt):
             other_adata=self.adata_tgt,
             batch_size=batch_size,
             cell_transition_kwargs=cell_transition_kwargs,
-            scale_by_marginals=True,
+            scale_by_marginals=scale_by_marginals,
         )
 
     @property

--- a/src/moscot/problems/cross_modality/_mixins.py
+++ b/src/moscot/problems/cross_modality/_mixins.py
@@ -9,11 +9,12 @@ from moscot import _constants
 from moscot._types import ArrayLike, Str_Dict_t
 from moscot.base.problems._mixins import AnalysisMixin
 from moscot.base.problems.compound_problem import B, K
+from moscot.base.problems.problem import AbstractSrcTgt
 
 __all__ = ["CrossModalityTranslationMixin"]
 
 
-class CrossModalityTranslationMixin(AnalysisMixin[K, B]):
+class CrossModalityTranslationMixin(AnalysisMixin[K, B], AbstractSrcTgt):
     """Cross modality translation analysis mixin class."""
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
@@ -22,7 +23,7 @@ class CrossModalityTranslationMixin(AnalysisMixin[K, B]):
         self._tgt_attr: Optional[Dict[str, Any]] = None
         self._batch_key: Optional[str] = None
 
-    def translate(  # type: ignore[misc]
+    def translate(
         self,
         source: K,
         target: K,
@@ -92,7 +93,7 @@ class CrossModalityTranslationMixin(AnalysisMixin[K, B]):
         adata_src = self.adata_src if self.batch_key is None else prob.adata_src
         return prob.push(_get_features(adata_src, attr=src_attr), **kwargs)
 
-    def cell_transition(  # type: ignore[misc]
+    def cell_transition(
         self,
         source: K,
         target: Optional[K] = None,
@@ -171,16 +172,16 @@ class CrossModalityTranslationMixin(AnalysisMixin[K, B]):
             key_added=key_added,
         )
 
-    def annotation_mapping(  # type: ignore[misc]
+    def annotation_mapping(
         self,
         mapping_mode: Literal["sum", "max"],
         annotation_label: str,
         forward: bool,
-        source: str = "src",
-        target: str = "tgt",
+        source: K = "src",
+        target: K = "tgt",
         batch_size: Optional[int] = None,
         cell_transition_kwargs: Mapping[str, Any] = types.MappingProxyType({}),
-        **kwargs: Mapping[str, Any],
+        scale_by_marginals: bool = True,
     ) -> pd.DataFrame:
         """Transfer annotations between distributions.
 
@@ -208,6 +209,9 @@ class CrossModalityTranslationMixin(AnalysisMixin[K, B]):
             If :obj:`None`, the entire cost matrix will be materialized.
         cell_transition_kwargs
             Keyword arguments for :meth:`cell_transition`, used only if ``mapping_mode = 'sum'``.
+        scale_by_marginals
+            todo
+
 
         Returns
         -------
@@ -223,7 +227,7 @@ class CrossModalityTranslationMixin(AnalysisMixin[K, B]):
             other_adata=self.adata_tgt,
             batch_size=batch_size,
             cell_transition_kwargs=cell_transition_kwargs,
-            **kwargs,
+            scale_by_marginals=True,
         )
 
     @property
@@ -233,6 +237,6 @@ class CrossModalityTranslationMixin(AnalysisMixin[K, B]):
 
     @batch_key.setter
     def batch_key(self, key: Optional[str]) -> None:
-        if key is not None and key not in self.adata.obs:  # type: ignore[attr-defined]
+        if key is not None and key not in self.adata.obs:
             raise KeyError(f"Unable to find batch data in `adata.obs[{key!r}]`.")
         self._batch_key = key

--- a/src/moscot/problems/cross_modality/_translation.py
+++ b/src/moscot/problems/cross_modality/_translation.py
@@ -22,7 +22,7 @@ from moscot.utils.subset_policy import DummyPolicy, ExternalStarPolicy
 __all__ = ["TranslationProblem"]
 
 
-class TranslationProblem(CrossModalityTranslationMixin[K, OTProblem], CompoundProblem[K, OTProblem]):
+class TranslationProblem(CompoundProblem[K, OTProblem], CrossModalityTranslationMixin[K, OTProblem]):
     """Class for integrating single-cell multi-omics data, based on :cite:`demetci-scot:22`.
 
     Parameters

--- a/src/moscot/problems/generic/_generic.py
+++ b/src/moscot/problems/generic/_generic.py
@@ -128,7 +128,7 @@ class SinkhornProblem(GenericAnalysisMixin[K, B], CompoundProblem[K, B]):  # typ
         - :attr:`stage` - set to ``'prepared'``.
         - :attr:`problem_kind` - set to ``'linear'``.
         """
-        self.batch_key = key  # type: ignore[misc]
+        self.batch_key = key
         xy, xy_callback, xy_callback_kwargs = handle_joint_attr(joint_attr, xy_callback, xy_callback_kwargs)
         xy, _, _ = handle_cost(
             xy=xy,
@@ -366,7 +366,7 @@ class GWProblem(GenericAnalysisMixin[K, B], CompoundProblem[K, B]):  # type: ign
         - :attr:`stage` - set to ``'prepared'``.
         - :attr:`problem_kind` - set to ``'quadratic'``.
         """
-        self.batch_key = key  # type: ignore[misc]
+        self.batch_key = key
         x = set_quad_defaults(x_attr) if x_callback is None else {}
         y = set_quad_defaults(y_attr) if y_callback is None else {}
 
@@ -630,7 +630,7 @@ class FGWProblem(GWProblem[K, B]):
         - :attr:`stage` - set to ``'prepared'``.
         - :attr:`problem_kind` - set to ``'quadratic'``.
         """
-        self.batch_key = key  # type: ignore[misc]
+        self.batch_key = key
         x = set_quad_defaults(x_attr) if x_callback is None else {}
         y = set_quad_defaults(y_attr) if y_callback is None else {}
         xy, xy_callback, xy_callback_kwargs = handle_joint_attr(joint_attr, xy_callback, xy_callback_kwargs)
@@ -792,7 +792,7 @@ class GENOTLinProblem(CondOTProblem, GenericAnalysisMixin[K, B]):
         **kwargs: Any,
     ) -> "GENOTLinProblem[K, B]":
         """Prepare the :class:`moscot.problems.generic.GENOTLinProblem`."""
-        self.batch_key = key  # type:ignore[misc]
+        self.batch_key = key
         xy, kwargs = handle_joint_attr_tmp(joint_attr, kwargs)
         conditions = handle_conditional_attr(conditional_attr)
         xy, xx = handle_cost_tmp(xy=xy, x={}, y={}, cost=cost, cost_kwargs=cost_kwargs)

--- a/src/moscot/problems/generic/_generic.py
+++ b/src/moscot/problems/generic/_generic.py
@@ -776,7 +776,7 @@ class FGWProblem(GWProblem[K, B]):
         return _constants.SEQUENTIAL, _constants.EXPLICIT, _constants.STAR  # type: ignore[return-value]
 
 
-class GENOTLinProblem(CondOTProblem, GenericAnalysisMixin[K, B]):
+class GENOTLinProblem(CondOTProblem):
     """Class for solving Conditional Parameterized Monge Map problems / Conditional Neural OT problems."""
 
     def prepare(

--- a/src/moscot/problems/generic/_generic.py
+++ b/src/moscot/problems/generic/_generic.py
@@ -790,7 +790,7 @@ class GENOTLinProblem(CondOTProblem):
         cost: OttCostFn_t = "sq_euclidean",
         cost_kwargs: CostKwargs_t = types.MappingProxyType({}),
         **kwargs: Any,
-    ) -> "GENOTLinProblem[K, B]":
+    ) -> "GENOTLinProblem":
         """Prepare the :class:`moscot.problems.generic.GENOTLinProblem`."""
         self.batch_key = key
         xy, kwargs = handle_joint_attr_tmp(joint_attr, kwargs)
@@ -816,7 +816,7 @@ class GENOTLinProblem(CondOTProblem):
         valid_sinkhorn_kwargs: Dict[str, Any] = MappingProxyType({}),
         train_size: float = 1.0,
         **kwargs: Any,
-    ) -> "GENOTLinProblem[K, B]":
+    ) -> "GENOTLinProblem":
         """Solve."""
         return super().solve(
             batch_size=batch_size,

--- a/src/moscot/problems/generic/_mixins.py
+++ b/src/moscot/problems/generic/_mixins.py
@@ -2,7 +2,6 @@ from typing import TYPE_CHECKING, Any, List, Literal, Optional, Tuple, Union
 
 import pandas as pd
 
-
 from moscot import _constants
 from moscot._types import ArrayLike, Str_Dict_t
 from moscot.base.problems._mixins import AnalysisMixin

--- a/src/moscot/problems/generic/_mixins.py
+++ b/src/moscot/problems/generic/_mixins.py
@@ -1,30 +1,15 @@
-from typing import TYPE_CHECKING, Any, List, Literal, Optional, Protocol, Tuple, Union
+from typing import TYPE_CHECKING, Any, List, Literal, Optional, Tuple, Union
 
 import pandas as pd
 
-from anndata import AnnData
 
 from moscot import _constants
 from moscot._types import ArrayLike, Str_Dict_t
-from moscot.base.problems._mixins import AnalysisMixin, AnalysisMixinProtocol
+from moscot.base.problems._mixins import AnalysisMixin
 from moscot.base.problems.compound_problem import ApplyOutput_t, B, K
 from moscot.plotting._utils import set_plotting_vars
 
 __all__ = ["GenericAnalysisMixin"]
-
-
-class GenericAnalysisMixinProtocol(AnalysisMixinProtocol[K, B], Protocol[K, B]):
-    """Protocol class."""
-
-    _batch_key: Optional[str]
-    batch_key: Optional[str]
-    adata: AnnData
-
-    def _cell_transition(
-        self: AnalysisMixinProtocol[K, B],
-        *args: Any,
-        **kwargs: Any,
-    ) -> pd.DataFrame: ...
 
 
 class GenericAnalysisMixin(AnalysisMixin[K, B]):
@@ -35,7 +20,7 @@ class GenericAnalysisMixin(AnalysisMixin[K, B]):
         self._batch_key: Optional[str] = None
 
     def cell_transition(
-        self: GenericAnalysisMixinProtocol[K, B],
+        self,
         source: K,
         target: K,
         source_groups: Optional[Str_Dict_t] = None,
@@ -112,7 +97,7 @@ class GenericAnalysisMixin(AnalysisMixin[K, B]):
         )
 
     def push(
-        self: GenericAnalysisMixinProtocol[K, B],
+        self,
         source: K,
         target: K,
         data: Optional[Union[str, ArrayLike]] = None,
@@ -181,7 +166,7 @@ class GenericAnalysisMixin(AnalysisMixin[K, B]):
         return result
 
     def pull(
-        self: GenericAnalysisMixinProtocol[K, B],
+        self,
         source: K,
         target: K,
         data: Optional[Union[str, ArrayLike]] = None,
@@ -247,12 +232,12 @@ class GenericAnalysisMixin(AnalysisMixin[K, B]):
         return result
 
     @property
-    def batch_key(self: GenericAnalysisMixinProtocol[K, B]) -> Optional[str]:
+    def batch_key(self) -> Optional[str]:
         """Batch key in :attr:`~anndata.AnnData.obs`."""
         return self._batch_key
 
     @batch_key.setter
-    def batch_key(self: GenericAnalysisMixinProtocol[K, B], key: Optional[str]) -> None:
+    def batch_key(self, key: Optional[str]) -> None:
         if key is not None and key not in self.adata.obs:
             raise KeyError(f"Unable to find batch data in `adata.obs[{key!r}]`.")
         self._batch_key = key

--- a/src/moscot/problems/space/_mapping.py
+++ b/src/moscot/problems/space/_mapping.py
@@ -359,7 +359,7 @@ class MappingProblem(SpatialMappingMixin[K, OTProblem], CompoundProblem[K, OTPro
 
     @filtered_vars.setter
     def filtered_vars(self, value: Optional[Sequence[str]]) -> None:
-        self._filtered_vars = self._filter_vars(var_names=value)  # type: ignore[misc]
+        self._filtered_vars = self._filter_vars(var_names=value)
 
     @property
     def _base_problem_type(self) -> Type[B]:

--- a/src/moscot/problems/space/_mixins.py
+++ b/src/moscot/problems/space/_mixins.py
@@ -30,12 +30,13 @@ from moscot._logging import logger
 from moscot._types import ArrayLike, Device_t, Str_Dict_t
 from moscot.base.problems._mixins import AnalysisMixin
 from moscot.base.problems.compound_problem import B, K
+from moscot.base.problems.problem import AbstractSpSc, AbstractSrcTgt
 from moscot.utils.subset_policy import StarPolicy
 
 __all__ = ["SpatialAlignmentMixin", "SpatialMappingMixin"]
 
 
-class SpatialAlignmentMixin(AnalysisMixin[K, B]):
+class SpatialAlignmentMixin(AnalysisMixin[K, B], AbstractSrcTgt):
     """Spatial alignment mixin class."""
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
@@ -43,7 +44,7 @@ class SpatialAlignmentMixin(AnalysisMixin[K, B]):
         self._spatial_key: Optional[str] = None
         self._batch_key: Optional[str] = None
 
-    def _interpolate_scheme(  # type: ignore[misc]
+    def _interpolate_scheme(
         self,
         reference: K,
         mode: Literal["warp", "affine"],
@@ -87,7 +88,7 @@ class SpatialAlignmentMixin(AnalysisMixin[K, B]):
         # TODO(michalk8): always return the metadata?
         return transport_maps, (transport_metadata if mode == "affine" else None)
 
-    def align(  # type: ignore[misc]
+    def align(
         self,
         reference: Optional[K] = None,
         mode: Literal["warp", "affine"] = "warp",
@@ -147,7 +148,7 @@ class SpatialAlignmentMixin(AnalysisMixin[K, B]):
             self.adata.uns.setdefault(key_added, {})
             self.adata.uns[key_added]["alignment_metadata"] = aligned_metadata  # noqa: RET503
 
-    def cell_transition(  # type: ignore[misc]
+    def cell_transition(
         self,
         source: K,
         target: K,
@@ -225,16 +226,17 @@ class SpatialAlignmentMixin(AnalysisMixin[K, B]):
             key_added=key_added,
         )
 
-    def annotation_mapping(  # type: ignore[misc]
+    def annotation_mapping(
         self,
         mapping_mode: Literal["sum", "max"],
         annotation_label: str,
         forward: bool,
-        source: str = "src",
-        target: str = "tgt",
+        source: K = "src",
+        target: K = "tgt",
         batch_size: Optional[int] = None,
         cell_transition_kwargs: Mapping[str, Any] = types.MappingProxyType({}),
-        **kwargs: Mapping[str, Any],
+        other_adata: Optional[AnnData] = None,
+        scale_by_marginals: bool = True,
     ) -> pd.DataFrame:
         """Transfer annotations between distributions.
 
@@ -262,6 +264,10 @@ class SpatialAlignmentMixin(AnalysisMixin[K, B]):
             If :obj:`None`, the entire cost matrix will be materialized.
         cell_transition_kwargs
             Keyword arguments for :meth:`cell_transition`, used only if ``mapping_mode = 'sum'``.
+        other_adata
+            The other :class:`~anndata.AnnData` object to use for the cell transition.
+        scale_by_marginals
+            If :obj:`True`, scale the transition matrix by marginals.
 
         Returns
         -------
@@ -276,7 +282,8 @@ class SpatialAlignmentMixin(AnalysisMixin[K, B]):
             forward=forward,
             batch_size=batch_size,
             cell_transition_kwargs=cell_transition_kwargs,
-            **kwargs,
+            other_adata=other_adata,
+            scale_by_marginals=scale_by_marginals,
         )
 
     @property
@@ -285,7 +292,7 @@ class SpatialAlignmentMixin(AnalysisMixin[K, B]):
         return self._spatial_key
 
     @spatial_key.setter
-    def spatial_key(self, key: Optional[str]) -> None:  # type: ignore[misc]
+    def spatial_key(self, key: Optional[str]) -> None:
         if key is not None and key not in self.adata.obsm:
             raise KeyError(f"Unable to find spatial data in `adata.obsm[{key!r}]`.")
         self._spatial_key = key
@@ -297,11 +304,11 @@ class SpatialAlignmentMixin(AnalysisMixin[K, B]):
 
     @batch_key.setter
     def batch_key(self, key: Optional[str]) -> None:
-        if key is not None and key not in self.adata.obs:  # type: ignore[attr-defined]
+        if key is not None and key not in self.adata.obs:
             raise KeyError(f"Unable to find batch data in `adata.obs[{key!r}]`.")
         self._batch_key = key
 
-    def _subset_spatial(  # type: ignore[misc]
+    def _subset_spatial(
         self,
         k: K,
         spatial_key: str,
@@ -310,7 +317,7 @@ class SpatialAlignmentMixin(AnalysisMixin[K, B]):
         return self.adata[mask].obsm[spatial_key].astype(float, copy=True)
 
 
-class SpatialMappingMixin(AnalysisMixin[K, B]):
+class SpatialMappingMixin(AnalysisMixin[K, B], AbstractSpSc):
     """Spatial mapping analysis mixin class."""
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
@@ -318,7 +325,7 @@ class SpatialMappingMixin(AnalysisMixin[K, B]):
         self._batch_key: Optional[str] = None
         self._spatial_key: Optional[str] = None
 
-    def _filter_vars(  # type: ignore[misc]
+    def _filter_vars(
         self,
         var_names: Optional[Sequence[str]] = None,
     ) -> Optional[List[str]]:
@@ -340,7 +347,7 @@ class SpatialMappingMixin(AnalysisMixin[K, B]):
 
         raise ValueError("Some variable are missing in the single-cell or the spatial `AnnData`.")
 
-    def correlate(  # type: ignore[misc]
+    def correlate(
         self,
         var_names: Optional[Sequence[str]] = None,
         corr_method: Literal["pearson", "spearman"] = "pearson",
@@ -439,7 +446,7 @@ class SpatialMappingMixin(AnalysisMixin[K, B]):
 
         return corrs
 
-    def impute(  # type: ignore[misc]
+    def impute(
         self,
         var_names: Optional[Sequence[str]] = None,
         device: Optional[Device_t] = None,
@@ -494,7 +501,7 @@ class SpatialMappingMixin(AnalysisMixin[K, B]):
 
         return adata_pred
 
-    def spatial_correspondence(  # type: ignore[misc]
+    def spatial_correspondence(
         self,
         interval: Union[int, ArrayLike] = 10,
         max_dist: Optional[int] = None,
@@ -555,7 +562,7 @@ class SpatialMappingMixin(AnalysisMixin[K, B]):
         res[self.batch_key] = res[self.batch_key].astype("category")  # type: ignore[call-overload]
         return res
 
-    def cell_transition(  # type: ignore[misc]
+    def cell_transition(
         self,
         source: K,
         target: Optional[K] = None,
@@ -620,7 +627,7 @@ class SpatialMappingMixin(AnalysisMixin[K, B]):
         return self._cell_transition(
             key=self.batch_key,
             source=source,
-            target=target,
+            target=target or None,
             source_groups=source_groups,
             target_groups=target_groups,
             forward=forward,
@@ -632,16 +639,16 @@ class SpatialMappingMixin(AnalysisMixin[K, B]):
             key_added=key_added,
         )
 
-    def annotation_mapping(  # type: ignore[misc]
+    def annotation_mapping(
         self,
         mapping_mode: Literal["sum", "max"],
         annotation_label: str,
         source: K,
-        target: Union[K, str] = "tgt",
+        target: K = "tgt",
         forward: bool = False,
         batch_size: Optional[int] = None,
         cell_transition_kwargs: Mapping[str, Any] = types.MappingProxyType({}),
-        **kwargs: Mapping[str, Any],
+        scale_by_marginals: bool = True,
     ) -> pd.DataFrame:
         """Transfer annotations between distributions.
 
@@ -669,6 +676,8 @@ class SpatialMappingMixin(AnalysisMixin[K, B]):
             If :obj:`None`, the entire cost matrix will be materialized.
         cell_transition_kwargs
             Keyword arguments for :meth:`cell_transition`, used only if ``mapping_mode = 'sum'``.
+        scale_by_marginals
+            todo
 
         Returns
         -------
@@ -684,7 +693,7 @@ class SpatialMappingMixin(AnalysisMixin[K, B]):
             other_adata=self.adata_sc,
             batch_size=batch_size,
             cell_transition_kwargs=cell_transition_kwargs,
-            **kwargs,
+            scale_by_marginals=scale_by_marginals,
         )
 
     @property
@@ -694,7 +703,7 @@ class SpatialMappingMixin(AnalysisMixin[K, B]):
 
     @batch_key.setter
     def batch_key(self, key: Optional[str]) -> None:
-        if key is not None and key not in self.adata.obs:  # type: ignore[attr-defined]
+        if key is not None and key not in self.adata.obs:
             raise KeyError(f"Unable to find batch data in `adata.obs[{key!r}]`.")
         self._batch_key = key
 
@@ -704,7 +713,7 @@ class SpatialMappingMixin(AnalysisMixin[K, B]):
         return self._spatial_key
 
     @spatial_key.setter
-    def spatial_key(self, key: Optional[str]) -> None:  # type: ignore[misc]
+    def spatial_key(self, key: Optional[str]) -> None:
         if key is not None and key not in self.adata.obsm:
             raise KeyError(f"Unable to find spatial data in `adata.obsm[{key!r}]`.")
         self._spatial_key = key

--- a/src/moscot/problems/space/_mixins.py
+++ b/src/moscot/problems/space/_mixins.py
@@ -265,9 +265,9 @@ class SpatialAlignmentMixin(AnalysisMixin[K, B]):
         cell_transition_kwargs
             Keyword arguments for :meth:`cell_transition`, used only if ``mapping_mode = 'sum'``.
         other_adata
-            The other :class:`~anndata.AnnData` object to use for the cell transition.
+            TODO
         scale_by_marginals
-            If :obj:`True`, scale the transition matrix by marginals.
+            TODO
 
         Returns
         -------

--- a/src/moscot/problems/space/_mixins.py
+++ b/src/moscot/problems/space/_mixins.py
@@ -30,13 +30,13 @@ from moscot._logging import logger
 from moscot._types import ArrayLike, Device_t, Str_Dict_t
 from moscot.base.problems._mixins import AnalysisMixin
 from moscot.base.problems.compound_problem import B, K
-from moscot.base.problems.problem import AbstractSpSc, AbstractSrcTgt
+from moscot.base.problems.problem import AbstractSpSc
 from moscot.utils.subset_policy import StarPolicy
 
 __all__ = ["SpatialAlignmentMixin", "SpatialMappingMixin"]
 
 
-class SpatialAlignmentMixin(AnalysisMixin[K, B], AbstractSrcTgt):
+class SpatialAlignmentMixin(AnalysisMixin[K, B]):
     """Spatial alignment mixin class."""
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:

--- a/src/moscot/problems/space/_mixins.py
+++ b/src/moscot/problems/space/_mixins.py
@@ -265,9 +265,9 @@ class SpatialAlignmentMixin(AnalysisMixin[K, B]):
         cell_transition_kwargs
             Keyword arguments for :meth:`cell_transition`, used only if ``mapping_mode = 'sum'``.
         other_adata
-            TODO
+            Other adata object to use for the cell transitions.
         scale_by_marginals
-            TODO
+            Whether to scale by the source/target :term:`marginals`.
 
         Returns
         -------
@@ -677,7 +677,7 @@ class SpatialMappingMixin(AnalysisMixin[K, B], AbstractSpSc):
         cell_transition_kwargs
             Keyword arguments for :meth:`cell_transition`, used only if ``mapping_mode = 'sum'``.
         scale_by_marginals
-            todo
+            Whether to scale by the source/target :term:`marginals`.
 
         Returns
         -------

--- a/src/moscot/problems/space/_mixins.py
+++ b/src/moscot/problems/space/_mixins.py
@@ -28,63 +28,11 @@ from anndata import AnnData
 from moscot import _constants
 from moscot._logging import logger
 from moscot._types import ArrayLike, Device_t, Str_Dict_t
-from moscot.base.problems._mixins import AnalysisMixin, AnalysisMixinProtocol
+from moscot.base.problems._mixins import AnalysisMixin
 from moscot.base.problems.compound_problem import B, K
 from moscot.utils.subset_policy import StarPolicy
 
 __all__ = ["SpatialAlignmentMixin", "SpatialMappingMixin"]
-
-
-class SpatialAlignmentMixinProtocol(AnalysisMixinProtocol[K, B]):
-    """Protocol class."""
-
-    spatial_key: Optional[str]
-    _spatial_key: Optional[str]
-    batch_key: Optional[str]
-
-    def _subset_spatial(  # type:ignore[empty-body]
-        self: "SpatialAlignmentMixinProtocol[K, B]",
-        k: K,
-        spatial_key: str,
-    ) -> ArrayLike: ...
-
-    def _interpolate_scheme(  # type:ignore[empty-body]
-        self: "SpatialAlignmentMixinProtocol[K, B]",
-        reference: K,
-        mode: Literal["warp", "affine"],
-        spatial_key: str,
-    ) -> Tuple[Dict[K, ArrayLike], Optional[Dict[K, Optional[ArrayLike]]]]: ...
-
-    def _cell_transition(
-        self: AnalysisMixinProtocol[K, B],
-        *args: Any,
-        **kwargs: Any,
-    ) -> pd.DataFrame: ...
-
-    def _annotation_mapping(
-        self: AnalysisMixinProtocol[K, B],
-        *args: Any,
-        **kwargs: Any,
-    ) -> pd.DataFrame: ...
-
-
-class SpatialMappingMixinProtocol(AnalysisMixinProtocol[K, B]):
-    """Protocol class."""
-
-    adata_sc: AnnData
-    adata_sp: AnnData
-    batch_key: Optional[str]
-    spatial_key: Optional[str]
-    _spatial_key: Optional[str]
-
-    def _filter_vars(
-        self: "SpatialMappingMixinProtocol[K, B]",
-        var_names: Optional[Sequence[str]] = None,
-    ) -> Optional[List[str]]: ...
-
-    def _cell_transition(self: AnalysisMixinProtocol[K, B], *args: Any, **kwargs: Any) -> pd.DataFrame: ...
-
-    def _annotation_mapping(self: AnalysisMixinProtocol[K, B], *args: Any, **kwargs: Any) -> pd.DataFrame: ...
 
 
 class SpatialAlignmentMixin(AnalysisMixin[K, B]):
@@ -96,7 +44,7 @@ class SpatialAlignmentMixin(AnalysisMixin[K, B]):
         self._batch_key: Optional[str] = None
 
     def _interpolate_scheme(  # type: ignore[misc]
-        self: SpatialAlignmentMixinProtocol[K, B],
+        self,
         reference: K,
         mode: Literal["warp", "affine"],
         spatial_key: str,
@@ -140,7 +88,7 @@ class SpatialAlignmentMixin(AnalysisMixin[K, B]):
         return transport_maps, (transport_metadata if mode == "affine" else None)
 
     def align(  # type: ignore[misc]
-        self: SpatialAlignmentMixinProtocol[K, B],
+        self,
         reference: Optional[K] = None,
         mode: Literal["warp", "affine"] = "warp",
         spatial_key: Optional[str] = None,
@@ -200,7 +148,7 @@ class SpatialAlignmentMixin(AnalysisMixin[K, B]):
             self.adata.uns[key_added]["alignment_metadata"] = aligned_metadata  # noqa: RET503
 
     def cell_transition(  # type: ignore[misc]
-        self: SpatialAlignmentMixinProtocol[K, B],
+        self,
         source: K,
         target: K,
         source_groups: Optional[Str_Dict_t] = None,
@@ -278,7 +226,7 @@ class SpatialAlignmentMixin(AnalysisMixin[K, B]):
         )
 
     def annotation_mapping(  # type: ignore[misc]
-        self: SpatialAlignmentMixinProtocol[K, B],
+        self,
         mapping_mode: Literal["sum", "max"],
         annotation_label: str,
         forward: bool,
@@ -337,7 +285,7 @@ class SpatialAlignmentMixin(AnalysisMixin[K, B]):
         return self._spatial_key
 
     @spatial_key.setter
-    def spatial_key(self: SpatialAlignmentMixinProtocol[K, B], key: Optional[str]) -> None:  # type: ignore[misc]
+    def spatial_key(self, key: Optional[str]) -> None:  # type: ignore[misc]
         if key is not None and key not in self.adata.obsm:
             raise KeyError(f"Unable to find spatial data in `adata.obsm[{key!r}]`.")
         self._spatial_key = key
@@ -354,7 +302,7 @@ class SpatialAlignmentMixin(AnalysisMixin[K, B]):
         self._batch_key = key
 
     def _subset_spatial(  # type: ignore[misc]
-        self: SpatialAlignmentMixinProtocol[K, B],
+        self,
         k: K,
         spatial_key: str,
     ) -> ArrayLike:
@@ -371,7 +319,7 @@ class SpatialMappingMixin(AnalysisMixin[K, B]):
         self._spatial_key: Optional[str] = None
 
     def _filter_vars(  # type: ignore[misc]
-        self: SpatialMappingMixinProtocol[K, B],
+        self,
         var_names: Optional[Sequence[str]] = None,
     ) -> Optional[List[str]]:
         """Filter variables for the linear term."""
@@ -393,7 +341,7 @@ class SpatialMappingMixin(AnalysisMixin[K, B]):
         raise ValueError("Some variable are missing in the single-cell or the spatial `AnnData`.")
 
     def correlate(  # type: ignore[misc]
-        self: SpatialMappingMixinProtocol[K, B],
+        self,
         var_names: Optional[Sequence[str]] = None,
         corr_method: Literal["pearson", "spearman"] = "pearson",
         device: Optional[Device_t] = None,
@@ -492,7 +440,7 @@ class SpatialMappingMixin(AnalysisMixin[K, B]):
         return corrs
 
     def impute(  # type: ignore[misc]
-        self: SpatialMappingMixinProtocol[K, B],
+        self,
         var_names: Optional[Sequence[str]] = None,
         device: Optional[Device_t] = None,
         batch_size: Optional[int] = None,
@@ -547,7 +495,7 @@ class SpatialMappingMixin(AnalysisMixin[K, B]):
         return adata_pred
 
     def spatial_correspondence(  # type: ignore[misc]
-        self: SpatialMappingMixinProtocol[K, B],
+        self,
         interval: Union[int, ArrayLike] = 10,
         max_dist: Optional[int] = None,
         attr: Optional[Dict[str, Optional[str]]] = None,
@@ -608,7 +556,7 @@ class SpatialMappingMixin(AnalysisMixin[K, B]):
         return res
 
     def cell_transition(  # type: ignore[misc]
-        self: SpatialMappingMixinProtocol[K, B],
+        self,
         source: K,
         target: Optional[K] = None,
         source_groups: Optional[Str_Dict_t] = None,
@@ -685,7 +633,7 @@ class SpatialMappingMixin(AnalysisMixin[K, B]):
         )
 
     def annotation_mapping(  # type: ignore[misc]
-        self: SpatialMappingMixinProtocol[K, B],
+        self,
         mapping_mode: Literal["sum", "max"],
         annotation_label: str,
         source: K,
@@ -756,7 +704,7 @@ class SpatialMappingMixin(AnalysisMixin[K, B]):
         return self._spatial_key
 
     @spatial_key.setter
-    def spatial_key(self: SpatialAlignmentMixinProtocol[K, B], key: Optional[str]) -> None:  # type: ignore[misc]
+    def spatial_key(self, key: Optional[str]) -> None:  # type: ignore[misc]
         if key is not None and key not in self.adata.obsm:
             raise KeyError(f"Unable to find spatial data in `adata.obsm[{key!r}]`.")
         self._spatial_key = key

--- a/src/moscot/problems/time/_mixins.py
+++ b/src/moscot/problems/time/_mixins.py
@@ -141,7 +141,7 @@ class TemporalMixin(AnalysisMixin[K, B], AbstractSolutionsProblems):
         cell_transition_kwargs
             Keyword arguments for :meth:`cell_transition`, used only if ``mapping_mode = 'sum'``.
         scale_by_marginals
-            TODO
+            Whether to scale by the source/target :term:`marginals`.
 
         Returns
         -------

--- a/src/moscot/problems/time/_mixins.py
+++ b/src/moscot/problems/time/_mixins.py
@@ -2,15 +2,7 @@ from __future__ import annotations
 
 import itertools
 import types
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Literal,
-    Mapping,
-    Optional,
-    Sequence,
-    Union,
-)
+from typing import TYPE_CHECKING, Any, Literal, Mapping, Optional, Sequence, Union
 
 import numpy as np
 import pandas as pd

--- a/src/moscot/problems/time/_mixins.py
+++ b/src/moscot/problems/time/_mixins.py
@@ -141,7 +141,7 @@ class TemporalMixin(AnalysisMixin[K, B], AbstractSolutionsProblems):
         cell_transition_kwargs
             Keyword arguments for :meth:`cell_transition`, used only if ``mapping_mode = 'sum'``.
         scale_by_marginals
-            todo
+            TODO
 
         Returns
         -------

--- a/src/moscot/problems/time/_mixins.py
+++ b/src/moscot/problems/time/_mixins.py
@@ -1,17 +1,13 @@
 from __future__ import annotations
 
 import itertools
-import pathlib
 import types
 from typing import (
     TYPE_CHECKING,
     Any,
-    Iterable,
-    Iterator,
     Literal,
     Mapping,
     Optional,
-    Protocol,
     Sequence,
     Union,
 )
@@ -24,125 +20,12 @@ from anndata import AnnData
 
 from moscot import _constants
 from moscot._types import ArrayLike, Str_Dict_t
-from moscot.base.problems._mixins import AnalysisMixin, AnalysisMixinProtocol
-from moscot.base.problems.birth_death import BirthDeathProblem
+from moscot.base.problems._mixins import AnalysisMixin
 from moscot.base.problems.compound_problem import ApplyOutput_t, B, K
 from moscot.plotting._utils import set_plotting_vars
 from moscot.utils.tagged_array import Tag
 
 __all__ = ["TemporalMixin"]
-
-
-class TemporalMixinProtocol(AnalysisMixinProtocol[K, B], Protocol[K, B]):  # type: ignore[misc]
-    adata: AnnData
-    problems: dict[tuple[K, K], BirthDeathProblem]
-    temporal_key: Optional[str]
-    _temporal_key: Optional[str]
-
-    def cell_transition(  # noqa: D102
-        self: TemporalMixinProtocol[K, B],
-        source: K,
-        target: K,
-        source_groups: Str_Dict_t,
-        target_groups: Str_Dict_t,
-        forward: bool = False,  # return value will be row-stochastic if forward=True, else column-stochastic
-        aggregation_mode: Literal["annotation", "cell"] = "annotation",
-        batch_size: Optional[int] = None,
-        normalize: bool = True,
-        key_added: Optional[str] = _constants.CELL_TRANSITION,
-    ) -> pd.DataFrame: ...
-
-    def push(self, *args: Any, **kwargs: Any) -> Optional[ApplyOutput_t[K]]: ...
-
-    def pull(self, *args: Any, **kwargs: Any) -> Optional[ApplyOutput_t[K]]: ...
-
-    def _cell_transition(
-        self: AnalysisMixinProtocol[K, B],
-        *args: Any,
-        **kwargs: Any,
-    ) -> pd.DataFrame: ...
-
-    def _annotation_mapping(
-        self: AnalysisMixinProtocol[K, B],
-        *args: Any,
-        **kwargs: Any,
-    ) -> pd.DataFrame: ...
-
-    def _sample_from_tmap(
-        self: TemporalMixinProtocol[K, B],
-        source: K,
-        target: K,
-        n_samples: int,
-        source_dim: int,
-        target_dim: int,
-        batch_size: int = 256,
-        account_for_unbalancedness: bool = False,
-        interpolation_parameter: Optional[float] = None,
-        seed: Optional[int] = None,
-    ) -> tuple[list[Any], list[ArrayLike]]: ...
-
-    def _compute_wasserstein_distance(
-        self: TemporalMixinProtocol[K, B],
-        point_cloud_1: ArrayLike,
-        point_cloud_2: ArrayLike,
-        a: Optional[ArrayLike] = None,
-        b: Optional[ArrayLike] = None,
-        backend: Literal["ott"] = "ott",
-        **kwargs: Any,
-    ) -> float: ...
-
-    def _interpolate_gex_with_ot(
-        self: TemporalMixinProtocol[K, B],
-        number_cells: int,
-        source_data: ArrayLike,
-        target_data: ArrayLike,
-        source: K,
-        target: K,
-        interpolation_parameter: float,
-        account_for_unbalancedness: bool = True,
-        batch_size: int = 256,
-        seed: Optional[int] = None,
-    ) -> ArrayLike: ...
-
-    def _get_data(
-        self: TemporalMixinProtocol[K, B],
-        source: K,
-        intermediate: Optional[K] = None,
-        target: Optional[K] = None,
-        posterior_marginals: bool = True,
-        *,
-        only_start: bool = False,
-    ) -> Union[tuple[ArrayLike, AnnData], tuple[ArrayLike, ArrayLike, ArrayLike, AnnData, ArrayLike]]: ...
-
-    def _interpolate_gex_randomly(
-        self: TemporalMixinProtocol[K, B],
-        number_cells: int,
-        source_data: ArrayLike,
-        target_data: ArrayLike,
-        interpolation_parameter: float,
-        growth_rates: Optional[ArrayLike] = None,
-        seed: Optional[int] = None,
-    ) -> ArrayLike: ...
-
-    def _plot_temporal(
-        self: TemporalMixinProtocol[K, B],
-        data: dict[K, ArrayLike],
-        source: K,
-        target: K,
-        time_points: Optional[Iterable[K]] = None,
-        basis: str = "umap",
-        result_key: Optional[str] = None,
-        fill_value: float = 0.0,
-        save: Optional[Union[str, pathlib.Path]] = None,
-        **kwargs: Any,
-    ) -> None: ...
-
-    @staticmethod
-    def _get_interp_param(
-        source: K, intermediate: K, target: K, interpolation_parameter: Optional[float] = None
-    ) -> float: ...
-
-    def __iter__(self) -> Iterator[tuple[K, K]]: ...
 
 
 class TemporalMixin(AnalysisMixin[K, B]):
@@ -153,7 +36,7 @@ class TemporalMixin(AnalysisMixin[K, B]):
         self._temporal_key: Optional[str] = None
 
     def cell_transition(
-        self: TemporalMixinProtocol[K, B],
+        self,
         source: K,
         target: K,
         source_groups: Str_Dict_t,
@@ -228,7 +111,7 @@ class TemporalMixin(AnalysisMixin[K, B]):
         )
 
     def annotation_mapping(
-        self: TemporalMixinProtocol[K, B],
+        self,
         mapping_mode: Literal["sum", "max"],
         annotation_label: str,
         forward: bool,
@@ -283,7 +166,7 @@ class TemporalMixin(AnalysisMixin[K, B]):
         )
 
     def sankey(
-        self: TemporalMixinProtocol[K, B],
+        self,
         source: K,
         target: K,
         source_groups: Str_Dict_t,
@@ -405,7 +288,7 @@ class TemporalMixin(AnalysisMixin[K, B]):
         set_plotting_vars(self.adata, _constants.SANKEY, key=key_added, value=plot_vars)  # noqa: RET503
 
     def push(
-        self: TemporalMixinProtocol[K, B],
+        self,
         source: K,
         target: K,
         data: Optional[Union[str, ArrayLike]] = None,
@@ -472,7 +355,7 @@ class TemporalMixin(AnalysisMixin[K, B]):
         return result
 
     def pull(
-        self: TemporalMixinProtocol[K, B],
+        self,
         source: K,
         target: K,
         data: Optional[Union[str, ArrayLike]] = None,
@@ -538,7 +421,7 @@ class TemporalMixin(AnalysisMixin[K, B]):
         return result
 
     @property
-    def prior_growth_rates(self: TemporalMixinProtocol[K, B]) -> Optional[pd.DataFrame]:
+    def prior_growth_rates(self) -> Optional[pd.DataFrame]:
         """Prior estimate of the source growth rates."""
         computed = [isinstance(p.prior_growth_rates, np.ndarray) for p in self.problems.values()]
         if not np.sum(computed):
@@ -556,7 +439,7 @@ class TemporalMixin(AnalysisMixin[K, B]):
         return pd.concat([df_1, df_2], verify_integrity=True)
 
     @property
-    def posterior_growth_rates(self: TemporalMixinProtocol[K, B]) -> Optional[pd.DataFrame]:
+    def posterior_growth_rates(self) -> Optional[pd.DataFrame]:
         """Posterior estimate of the source growth rates."""
         computed = [isinstance(p.posterior_growth_rates, np.ndarray) for p in self.problems.values()]
         if not np.sum(computed):
@@ -574,7 +457,7 @@ class TemporalMixin(AnalysisMixin[K, B]):
         return pd.concat([df_1, df_2], verify_integrity=True)
 
     @property
-    def cell_costs_source(self: TemporalMixinProtocol[K, B]) -> Optional[pd.DataFrame]:
+    def cell_costs_source(self) -> Optional[pd.DataFrame]:
         """Cell cost obtained by the :term:`first dual potential <dual potentials>`.
 
         Only available for subproblems with :attr:`problem_kind = 'linear' <problem_kind>`.
@@ -599,7 +482,7 @@ class TemporalMixin(AnalysisMixin[K, B]):
         return pd.concat([df_1, df_2], verify_integrity=True)
 
     @property
-    def cell_costs_target(self: TemporalMixinProtocol[K, B]) -> Optional[pd.DataFrame]:
+    def cell_costs_target(self) -> Optional[pd.DataFrame]:
         """Cell cost obtained by the :term:`second dual potential <dual potentials>`.
 
         Only available for subproblems with :attr:`problem_kind = 'linear' <problem_kind>`.
@@ -624,7 +507,7 @@ class TemporalMixin(AnalysisMixin[K, B]):
         return pd.concat([df_1, df_2], verify_integrity=True)
 
     def _get_data(
-        self: TemporalMixinProtocol[K, B],
+        self,
         source: K,
         intermediate: Optional[K] = None,
         target: Optional[K] = None,
@@ -673,7 +556,7 @@ class TemporalMixin(AnalysisMixin[K, B]):
         )
 
     def compute_interpolated_distance(
-        self: TemporalMixinProtocol[K, B],
+        self,
         source: K,
         intermediate: K,
         target: K,
@@ -757,7 +640,7 @@ class TemporalMixin(AnalysisMixin[K, B]):
         return self._compute_wasserstein_distance(intermediate_data, interpolation, backend=backend, **kwargs)
 
     def compute_random_distance(
-        self: TemporalMixinProtocol[K, B],
+        self,
         source: K,
         intermediate: K,
         target: K,
@@ -831,7 +714,7 @@ class TemporalMixin(AnalysisMixin[K, B]):
         return self._compute_wasserstein_distance(intermediate_data, random_interpolation, backend=backend, **kwargs)
 
     def compute_time_point_distances(
-        self: TemporalMixinProtocol[K, B],
+        self,
         source: K,
         intermediate: K,
         target: K,
@@ -884,7 +767,7 @@ class TemporalMixin(AnalysisMixin[K, B]):
         return distance_source_intermediate, distance_intermediate_target
 
     def compute_batch_distances(
-        self: TemporalMixinProtocol[K, B],
+        self,
         time: K,
         batch_key: str,
         posterior_marginals: bool = True,
@@ -936,7 +819,7 @@ class TemporalMixin(AnalysisMixin[K, B]):
     # TODO(@MUCDK) possibly offer two alternatives, once exact EMD with POT backend and once approximate,
     # faster with same solver as used for original problems
     def _compute_wasserstein_distance(
-        self: TemporalMixinProtocol[K, B],
+        self,
         point_cloud_1: ArrayLike,
         point_cloud_2: ArrayLike,
         a: Optional[ArrayLike] = None,
@@ -951,7 +834,7 @@ class TemporalMixin(AnalysisMixin[K, B]):
         raise NotImplementedError("Only `ott` available as backend.")
 
     def _interpolate_gex_with_ot(
-        self: TemporalMixinProtocol[K, B],
+        self,
         number_cells: int,
         source_data: ArrayLike,
         target_data: ArrayLike,
@@ -979,7 +862,7 @@ class TemporalMixin(AnalysisMixin[K, B]):
         )
 
     def _interpolate_gex_randomly(
-        self: TemporalMixinProtocol[K, B],
+        self,
         number_cells: int,
         source_data: ArrayLike,
         target_data: ArrayLike,
@@ -1026,7 +909,7 @@ class TemporalMixin(AnalysisMixin[K, B]):
         return self._temporal_key
 
     @temporal_key.setter
-    def temporal_key(self: TemporalMixinProtocol[K, B], key: Optional[str]) -> None:
+    def temporal_key(self, key: Optional[str]) -> None:
         if key is None:
             self._temporal_key = key
             return


### PR DESCRIPTION
Solves [#765](https://github.com/theislab/moscot/issues/765)

There are some **cons** atm:

- I used Any  annotations in the abstract classes which is less specific than most of the protocols. See for example:
```python

class AbstractSolutionsProblems(ABC, metaclass=CombinedMeta):

    @property
    @abstractmethod
    def solutions(self) -> Any:
        """Solutions."""
        pass

    @property
    @abstractmethod
    def problems(self) -> Any:
        """Problems."""
        pass

    @property
    @abstractmethod
    def _policy(self) -> Any:
        """Subset policy."""
        pass
```
- For example one class uses src vs tgt terminology ( and other uses sp vs sc. They are essentially the same but I just rewrote them as is as two abstract classes. Otherwise it might also require more time to unify them.
These are the two classes I am talking about:
```python
class AbstractSrcTgt(ABC, metaclass=CombinedMeta):

    @property
    @abstractmethod
    def adata_src(self) -> AnnData:
        """Annotated data object."""
        pass

    @property
    @abstractmethod
    def adata_tgt(self) -> AnnData:
        """Annotated data object."""
        pass


class AbstractSpSc(ABC, metaclass=CombinedMeta):

    @property
    @abstractmethod
    def adata_sp(self) -> AnnData:
        """Annotated data object."""
        pass

    @property
    @abstractmethod
    def adata_sc(self) -> AnnData:
        """Annotated data object."""
        pass
```
- With the GENOT implementation `GENOTLinProblem` tries to inherit a class that requires `push/pull`
https://github.com/theislab/moscot/blob/f84f8be91e09a174edfbd1d4985e2dd575c0eafc/src/moscot/problems/generic/_generic.py#L779
**pros:**

- Less ignore comments for mypy
- Less code
- Better understanding of the expected attributes and methods


Things to do:
- Decide which files these new abstract classes should be in final version.
- Maybe fix the cons if important

