### PR TITLE
Fix jax version and neural

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,11 +54,16 @@ dependencies = [
     "scanpy>=1.9.3",
     "wrapt>=1.13.2",
     "docrep>=0.3.2",
+    "jax>=0.6.1",
     "ott-jax>=0.5.0",
     "cloudpickle>=2.2.0",
     "rich>=13.5",
     "docstring_inheritance>=2.0.0",
-    "mudata>=0.2.2"
+    "mudata>=0.2.2",
+    "optax",
+    "flax",
+    "diffrax",
+    "ott-jax[neural]>=0.5.0"
 ]
 
 [project.optional-dependencies]
@@ -66,13 +71,6 @@ spatial = [
     "squidpy>=1.2.3"
 ]
 
-neural = [
-    "optax",
-    "flax",
-    "diffrax",
-    "ott-jax[neural]>=0.5.0",
-
-]
 dev = [
     "pre-commit>=3.0.0",
     "tox>=4",


### PR DESCRIPTION
Addressing #832.
I added a requirement for the jax version to be >=0.6.1. If I understand correctly, this does not fix #830 though since the error appears when installing moscot with pip. So I think the error will still occur in the pip-downloaded version until the next release.

I moved all the requirements for moscot neural into the core dependencies to make their import not optional anymore.